### PR TITLE
✨Adds waiting for TCP port support

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -70,6 +70,8 @@ source "${__BASHIO_LIB_DIR}/host.sh"
 source "${__BASHIO_LIB_DIR}/info.sh"
 # shellcheck source=lib/jq.sh
 source "${__BASHIO_LIB_DIR}/jq.sh"
+# shellcheck source=lib/net.sh
+source "${__BASHIO_LIB_DIR}/net.sh"
 # shellcheck source=lib/pwned.sh
 source "${__BASHIO_LIB_DIR}/pwned.sh"
 # shellcheck source=lib/repositories.sh

--- a/lib/net.sh
+++ b/lib/net.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Community Hass.io Add-ons: Bashio
+# Bashio is an bash function library for use with Hass.io add-ons.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in add-on scripts to reduce code duplication across add-ons.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Wait for a TCP port to be available.
+#
+# Arguments:
+#   $1 Port to wait for
+#   $2 Interface/host the port should bind to (optional, default: localhost)
+#   $3 Timeout in seconds (option, defaults: 60)
+# ------------------------------------------------------------------------------
+bashio::net.wait_for() {
+    local port=${1}
+    local host=${2:-'localhost'}
+    local timeout=${3:-60}
+    local timeout_argument=""
+    local timeout_path
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    timeout_path=$(command -v timeout)
+    if [[ "$(realpath "${timeout_path}")" =~ "busybox" ]]; then
+        timeout_argument="-t"
+    fi
+
+    timeout ${timeout_argument} "${timeout}" \
+        bash -c \
+            "until echo > /dev/tcp/${host}/${port} ; do sleep 0.5; done" \
+                > /dev/null 2>&1;
+
+    return "${__BASHIO_EXIT_OK}"
+}


### PR DESCRIPTION
# Proposed Changes

Adds support for waiting for a TCP socket to be available. 
Useful for e.g., waiting for a subservice to be available/started, before starting NGinx.

```bash
bashio::net.wait_for 8080

exec nginx
```

## Related Issues

n/a

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/