### PR TITLE
Remove variable BASHIO_VERSION, because it is not in use

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -15,9 +15,6 @@ set -o pipefail # Return exit status of the last command in the pipe that failed
 # GLOBALS
 # ==============================================================================
 
-# Bashio version number
-readonly BASHIO_VERSION="0.1.0"
-
 # Stores the location of this library
 readonly __BASHIO_LIB_DIR=$(dirname "${BASH_SOURCE[0]}")
 


### PR DESCRIPTION
# Proposed Changes

This PR removes the variable `BASHIO_VERSION`.
This variable is
- not in use in the library
- out of date anyway

Based on my understanding, this is not needed.