### PR TITLE
Add Dockerfile and Dockerfile.dev for development of bashio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:bullseye-slim
+
+# Default ENV
+ENV LANG C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Base system
+ARG BASHIO_VERSION=0.7.1
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        jq \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && mkdir -p /tmp/bashio \
+    && curl -L -s https://github.com/hassio-addons/bashio/archive/v${BASHIO_VERSION}.tar.gz | tar -xzf - --strip 1 -C /tmp/bashio \
+    && mv /tmp/bashio/lib /usr/lib/bashio \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio \
+    && rm -rf /tmp/bashio
+
+ENTRYPOINT /bin/bash

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,20 @@
+FROM debian:bullseye-slim
+
+# Default ENV
+ENV LANG C.UTF-8
+ENV DEBIAN_FRONTEND noninteractive
+
+# Set shell
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Base system
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        bash \
+        jq \
+        curl \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    \
+    && ln -s /usr/lib/bashio/bashio /usr/bin/bashio
+
+ENTRYPOINT /bin/bash

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ provides the minimal needed base image for a great add-on.
 If you want to add Bashio to your own images, please take a look at the
 Dockerfile of the above base images to see how they are added at build time.
 
+### Standalone docker
+
+If you want to use _Bashio_ in a standalone version, use the existing [Dockerfile](./Dockerfile):
+
+```sh
+docker build -t bashio .
+docker run --rm -it bashio /bin/bash
+```
+
 ## Configuration
 
 Configuring an Bash script to use the Bashio library is fairly easy. Simply
@@ -97,6 +106,32 @@ function has been documented inside the code base.
 Further more, Bashio is used by the
 [Community Home Assistant Add-ons project][repository], those add-ons will be
 a great resource of practical examples.
+
+## Development
+
+We offer a Docker container for development purposes of _Bashio_:
+
+```
+git clone https://github.com/hassio-addons/bashio.git
+cd bashio
+docker build -f Dockerfile.dev -t bashio .
+docker run --rm -it -v ${PWD}/lib:/usr/lib/bashio -v ${PWD}:/usr/src/bashio bashio /bin/bash
+```
+
+Now, go ahead and create a `test.sh` with content like
+
+```
+#!/usr/bin/env bashio
+
+bashio::string.lower "FOO"
+```
+
+Inside the container, you can run:
+
+```
+cd /usr/src/bashio/
+./test.sh
+```
 
 ## Known issues and limitations
 


### PR DESCRIPTION
# Proposed Changes

As a newcomer to the Hassio / Home Assistant Ecosystem, it is quite hard to get an overview.
It is even harder if you run into issues and try to debug it (even with a software engineering background).
This happens to me with bashio and https://github.com/hassio-addons/addon-pi-hole/issues/116.

The documentation about every component is not really sufficient if you want to dig a bit deeper.
To understand bashio a bit more (and even able to debug it), I created 
- a standalone docker container
- a development focussed docker container

Furthermore, I added a few sentences about how to use it (for people who don't do this on a daily basis).

## Related Issues

https://github.com/hassio-addons/addon-pi-hole/issues/116