### PR TITLE
🔨 last_version -> version_latest

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -400,10 +400,10 @@ function bashio::addon.version() {
 # Arguments:
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
-function bashio::addon.last_version() {
+function bashio::addon.version_latest() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons "${slug}" "addons.${slug}.last_version" '.last_version'
+    bashio::addons "${slug}" "addons.${slug}.version_latest" '.version_latest'
 }
 
 # ------------------------------------------------------------------------------
@@ -415,14 +415,14 @@ function bashio::addon.last_version() {
 function bashio::addon.update_available() {
     local addon=${1:-'self'}
     local version
-    local last_version
+    local version_latest
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     version=$(bashio::addon.version "${addon}")
-    last_version=$(bashio::addon.last_version "${addon}")
+    version_latest=$(bashio::addon.version_latest "${addon}")
 
-    if [[ "${version}" = "${last_version}" ]]; then
+    if [[ "${version}" = "${version_latest}" ]]; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -116,9 +116,9 @@ function bashio::core.version() {
 # ------------------------------------------------------------------------------
 # Returns the latest version of Home Assistant.
 # ------------------------------------------------------------------------------
-function bashio::core.last_version() {
+function bashio::core.version_latest() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::core 'core.info.last_version' '.last_version'
+    bashio::core 'core.info.version_latest' '.version_latest'
 }
 
 # ------------------------------------------------------------------------------
@@ -126,14 +126,14 @@ function bashio::core.last_version() {
 # ------------------------------------------------------------------------------
 function bashio::supervisor.update_available() {
     local version
-    local last_version
+    local version_latest
 
     bashio::log.trace "${FUNCNAME[0]}"
 
     version=$(bashio::core.version)
-    last_version=$(bashio::core.last_version)
+    version_latest=$(bashio::core.version_latest)
 
-    if [[ "${version}" = "${last_version}" ]]; then
+    if [[ "${version}" = "${version_latest}" ]]; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -110,9 +110,9 @@ function bashio::dns.version() {
 # ------------------------------------------------------------------------------
 # Returns the latest version of the DNS.
 # ------------------------------------------------------------------------------
-function bashio::dns.last_version() {
+function bashio::dns.version_latest() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::dns 'dns.info.last_version' '.last_version'
+    bashio::dns 'dns.info.version_latest' '.version_latest'
 }
 
 # ------------------------------------------------------------------------------
@@ -120,14 +120,14 @@ function bashio::dns.last_version() {
 # ------------------------------------------------------------------------------
 function bashio::dns.update_available() {
     local version
-    local last_version
+    local version_latest
 
     bashio::log.trace "${FUNCNAME[0]}"
 
     version=$(bashio::dns.version)
-    last_version=$(bashio::dns.last_version)
+    version_latest=$(bashio::dns.version_latest)
 
-    if [[ "${version}" = "${last_version}" ]]; then
+    if [[ "${version}" = "${version_latest}" ]]; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -114,14 +114,14 @@ function bashio::os.version_latest() {
 # ------------------------------------------------------------------------------
 function bashio::os.update_available() {
     local version
-    local last_version
+    local version_latest
 
     bashio::log.trace "${FUNCNAME[0]}"
 
     version=$(bashio::os.version)
-    last_version=$(bashio::os.last_version)
+    version_latest=$(bashio::os.version_latest)
 
-    if [[ "${version}" = "${last_version}" ]]; then
+    if [[ "${version}" = "${version_latest}" ]]; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -101,9 +101,9 @@ function bashio::supervisor.version() {
 # ------------------------------------------------------------------------------
 # Returns the latest version of the Supervisor.
 # ------------------------------------------------------------------------------
-function bashio::supervisor.last_version() {
+function bashio::supervisor.version_latest() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::supervisor 'supervisor.info.last_version' '.last_version'
+    bashio::supervisor 'supervisor.info.version_latest' '.version_latest'
 }
 
 # ------------------------------------------------------------------------------
@@ -111,14 +111,14 @@ function bashio::supervisor.last_version() {
 # ------------------------------------------------------------------------------
 function bashio::supervisor.update_available() {
     local version
-    local last_version
+    local version_latest
 
     bashio::log.trace "${FUNCNAME[0]}"
 
     version=$(bashio::supervisor.version)
-    last_version=$(bashio::supervisor.last_version)
+    version_latest=$(bashio::supervisor.version_latest)
 
-    if [[ "${version}" = "${last_version}" ]]; then
+    if [[ "${version}" = "${version_latest}" ]]; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 


### PR DESCRIPTION
# Proposed Changes

Everything `last_version` was renamed to `version_latest` in the latest Supervisor API.
