### PR TITLE
Add Docker & Operating System info properties

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -132,3 +132,19 @@ function bashio::info.supported() {
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::info 'supervisor.info.supported' '.supported'
 }
+
+# ------------------------------------------------------------------------------
+# Returns the Docker version running on the system.
+# ------------------------------------------------------------------------------
+function bashio::info.docker() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::info 'supervisor.info.docker' '.docker'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the operating system running on the system.
+# ------------------------------------------------------------------------------
+function bashio::info.operating_system() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::info 'supervisor.info.operating_system' '.operating_system'
+}


### PR DESCRIPTION
# Proposed Changes

Add support for:

- `bashio::info.docker()`
- `bashio::info.operating_system()`

This will improve the startup time for add-ons in the community add-ons, and allows for the removal of API access for some add-ons.
