### PR TITLE
Replace update available logic with property access

### DIFF
--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -85,19 +85,8 @@ function bashio::cli.version_latest() {
 # Checks if there is an update available for the CLI.
 # ------------------------------------------------------------------------------
 function bashio::cli.update_available() {
-    local version
-    local version_latest
-
-    bashio::log.trace "${FUNCNAME[0]}"
-
-    version=$(bashio::cli.version)
-    version_latest=$(bashio::cli.version_latest)
-
-    if [[ "${version}" = "${version_latest}" ]]; then
-        return "${__BASHIO_EXIT_NOK}"
-    fi
-
-    return "${__BASHIO_EXIT_OK}"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    bashio::cli 'cli.info.update_available' '.update_available // false'
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -122,22 +122,11 @@ function bashio::core.version_latest() {
 }
 
 # ------------------------------------------------------------------------------
-# Checks if there is an update available for the Supervisor.
+# Checks if there is an update available for Home Assistant.
 # ------------------------------------------------------------------------------
-function bashio::supervisor.update_available() {
-    local version
-    local version_latest
-
-    bashio::log.trace "${FUNCNAME[0]}"
-
-    version=$(bashio::core.version)
-    version_latest=$(bashio::core.version_latest)
-
-    if [[ "${version}" = "${version_latest}" ]]; then
-        return "${__BASHIO_EXIT_NOK}"
-    fi
-
-    return "${__BASHIO_EXIT_OK}"
+function bashio::core.update_available() {
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    bashio::cli 'core.info.update_available' '.update_available // false'
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Proposed Changes

`bashio::core.update_available` & `bashio::cli.update_available` implemented their own logic to determine if there was an update available.

However, nowadays, that is just a property. So, just using that.