### PR TITLE
Fix slug: unbound variable in addon.update_available

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -438,6 +438,7 @@ function bashio::addon.version_latest() {
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.update_available() {
+    local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::addons \
         "${slug}" \


### PR DESCRIPTION
# Proposed Changes

Fixes an unbound variable occurrence in `bashio::addon.update_available`.


Causes: `/usr/lib/bashio/addons.sh: line 443: slug: unbound variable`