### PR TITLE
Using new cache location

### DIFF
--- a/lib/const.sh
+++ b/lib/const.sh
@@ -10,7 +10,7 @@
 
 # Defaults
 readonly __BASHIO_DEFAULT_ADDON_CONFIG="/data/options.json"
-readonly __BASHIO_DEFAULT_CACHE_DIR="/dev/shm/bashio"
+readonly __BASHIO_DEFAULT_CACHE_DIR="/tmp/bashio"
 readonly __BASHIO_DEFAULT_HIBP_ENDPOINT="https://api.pwnedpasswords.com/range"
 readonly __BASHIO_DEFAULT_LOG_FORMAT="[{TIMESTAMP}] {LEVEL}: {MESSAGE}"
 readonly __BASHIO_DEFAULT_LOG_LEVEL=5 # Defaults to INFO


### PR DESCRIPTION
# Proposed Changes

The platform started to using one shared shm to simplify the eco system. To make the cache only available for himself, we need to use the system tmp.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
