### PR TITLE
Put Bashio cache folder in a dot folder inside tmp

### DIFF
--- a/lib/const.sh
+++ b/lib/const.sh
@@ -10,7 +10,7 @@
 
 # Defaults
 readonly __BASHIO_DEFAULT_ADDON_CONFIG="/data/options.json"
-readonly __BASHIO_DEFAULT_CACHE_DIR="/tmp/bashio"
+readonly __BASHIO_DEFAULT_CACHE_DIR="/tmp/.bashio"
 readonly __BASHIO_DEFAULT_HIBP_ENDPOINT="https://api.pwnedpasswords.com/range"
 readonly __BASHIO_DEFAULT_LOG_FORMAT="[{TIMESTAMP}] {LEVEL}: {MESSAGE}"
 readonly __BASHIO_DEFAULT_LOG_LEVEL=5 # Defaults to INFO


### PR DESCRIPTION
# Proposed Changes

```
@Frenck I have tested bashio. My only mind would be if we not want use a dot
/tmp/.bashio/
instead of /tmp/bashio
```

Agreed.