### PR TITLE
Remove deprecated hardware trigger method

### DIFF
--- a/lib/hardware.sh
+++ b/lib/hardware.sh
@@ -84,11 +84,3 @@ function bashio::hardware.usb() {
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::hardware 'hardware.info.usb' '.usb[]'
 }
-
-# ------------------------------------------------------------------------------
-# Trigger udev device notifications from the host system.
-# ------------------------------------------------------------------------------
-function bashio::hardware.trigger() {
-    bashio::log.trace "${FUNCNAME[0]}"
-    bashio::api.supervisor POST /hardware/trigger
-}


### PR DESCRIPTION
# Proposed Changes

This PR removes the method `bashio::hardware.trigger()`.
It uses the now deprecated `/hardware/trigger`, thus the method is removed.
