### PR TITLE
Fix default value handling for configuration options

### DIFF
--- a/lib/config.sh
+++ b/lib/config.sh
@@ -12,10 +12,11 @@
 #
 # Arguments:
 #   $1 Key of the config option
+#   $2 Default value for not set config option (optional: defaults to 'null')
 # ------------------------------------------------------------------------------
 function bashio::config() {
     local key=${1}
-    local default_value=${2:-}
+    local default_value=${2:-null}
     local query
     local result
 
@@ -48,7 +49,7 @@ QUERY
     options=$(bashio::addon.config)
     result=$(bashio::jq "${options}" "${query}")
 
-    if [[ "${result}" == "null" ]] && bashio::var.has_value "${default_value}";
+    if [[ "${result}" == "null" ]];
     then
         echo "${default_value}"
     else


### PR DESCRIPTION
# Proposed Changes

0.14.0, introduced the possibility to pass a default value to the config options, in order to get a different default value returned if an option wasn't set by the user.

However, the default of the default value, was an empty string. This caused not set configuration options to become set...

This PR fixes that behavior by making the default value `null`, which is the same as not set.
It also saves a couple of calls this way :)

Tested with the Z-Wave JS @ MQTT add-on, which relies on this.