### PR TITLE
Fix processing of empty add-on config

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -562,6 +562,14 @@ function bashio::addon.config() {
 
     response=$(bashio::api.supervisor GET "/addons/self/options/config" false)
 
+    # If the add-on has no configuration, it returns an empty string.
+    # This is Bashio logic, that is problematic in this case, so make it a
+    # emtpty JSON object instead.
+    if bashio::var.is_empty "${response}";
+    then
+        response="{}"
+    fi
+
     bashio::cache.set "${cache_key}" "${response}"
     printf "%s" "${response}"
 


### PR DESCRIPTION
# Proposed Changes

Bashio handles `{}` as an empty value. This works nicely when working with Bash, as it doesn't handle dictionaries that well.

In the case of fetching the full configuration from the Supervisor API, this may lead to a surprising issue. If there is no add-on configuration, it returns `{}` is handled as empty by Bashio.

When later processing values from the empty config, `jq` simply returns empty results 🤷 
To prevent these issues, I've added a small check to ensure we return an empty JSON object when there is no add-on configuration.

This makes Bashio behave exactly the same as with the previous `options.json` method.