### PR TITLE
Allow multiple lines in var.json

### DIFF
--- a/lib/var.sh
+++ b/lib/var.sh
@@ -139,14 +139,17 @@ function bashio::var.json() {
 
     counter=0;
     for i in "${data[@]}"; do
+        item="\"$i\""
+
         separator=","
         if [ $((++counter%2)) -eq 0 ]; then
             separator=":";
-        fi
 
-        item="\"$i\""
-        if [[ "${i:0:1}" == "^" ]]; then
-            item="${i:1}"
+            if [[ "${i:0:1}" == "^" ]]; then
+                item="${i:1}"
+            else
+                item=$(bashio::var.json_string "${i}")
+            fi
         fi
 
         json="$json$separator$item";
@@ -154,5 +157,25 @@ function bashio::var.json() {
 
     echo "{${json:1}}";
     return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Escapes a string for use in a JSON object.
+#
+# Arguments:
+#   $1 String to escape
+# ------------------------------------------------------------------------------
+function bashio::var.json_string() {
+    local string="${1}"
+    local json_string
+
+    # https://stackoverflow.com/a/50380697/12156188
+    if json_string=$(echo -n "${string}" | jq -Rs .); then
+        echo "${json_string}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    bashio::log.error "Failed to escape string"
+    return "${__BASHIO_EXIT_NOK}"
 }
 


### PR DESCRIPTION
# Proposed Changes

- Allow new lines to be used in values for the `var.json`
- Properly escape all characters for a proper JSON string, not only line breaks
- Fix issue when `^` character would be used in a key and the key would evaluated as `key` rather than `"^key"` leading to a non-valid JSON
- Introduces a function `var.json_string` which escapes a Bash string for use in a JSON object

## Related Issues

Fixes #94
