### PR TITLE
Add error message for 403 error on API access

### DIFF
--- a/lib/api.sh
+++ b/lib/api.sh
@@ -64,10 +64,10 @@ function bashio::api.supervisor() {
         return "${__BASHIO_EXIT_NOK}"
     fi
 
-    if [[ "${status}" -eq 403 ]]; then                                          
-        bashio::log.error "Unable to access the API, forbidden"                    
-        return "${__BASHIO_EXIT_NOK}"                                           
-    fi                                                                          
+    if [[ "${status}" -eq 403 ]]; then
+        bashio::log.error "Unable to access the API, forbidden"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
 
     if [[ "${status}" -eq 404 ]]; then
         bashio::log.error "Requested resource ${resource} was not found"

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -64,6 +64,11 @@ function bashio::api.supervisor() {
         return "${__BASHIO_EXIT_NOK}"
     fi
 
+    if [[ "${status}" -eq 403 ]]; then                                          
+        bashio::log.error "Unable to access the API, forbidden"                    
+        return "${__BASHIO_EXIT_NOK}"                                           
+    fi                                                                          
+
     if [[ "${status}" -eq 404 ]]; then
         bashio::log.error "Requested resource ${resource} was not found"
         return "${__BASHIO_EXIT_NOK}"


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

When trying to develop an addon, I got messages like this appearing in the logs of the addon:

```
parse error: Expected string key before ':' at line 1, column 4
```
When all I was doing was:
```
HOST=$(bashio::host)
```

It turned out this was caused by a jq statement trying to parse the string
```
403: Forbidden
```
By adding this extra error message, we give developers a bit more of a hint as to what is wrong.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
