### PR TITLE
Fix comment/docs typo in info.state

### DIFF
--- a/lib/info.sh
+++ b/lib/info.sh
@@ -150,7 +150,7 @@ function bashio::info.operating_system() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns the current state of Home Assistant Core
+# Returns the current state of Home Assistant Supervisor
 # ------------------------------------------------------------------------------
 function bashio::info.state() {
     bashio::log.trace "${FUNCNAME[0]}"


### PR DESCRIPTION
# Proposed Changes

Typo introduced in #142 (code is OK, only the comment is misleading)

## Related Issues
