### PR TITLE
Properly quote replacment string in param expansion

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -111,9 +111,9 @@ function bashio::log.log() {
     timestamp=$(date +"${__BASHIO_LOG_TIMESTAMP}")
 
     output="${__BASHIO_LOG_FORMAT}"
-    output="${output//\{TIMESTAMP\}/${timestamp}}"
-    output="${output//\{MESSAGE\}/${message}}"
-    output="${output//\{LEVEL\}/${__BASHIO_LOG_LEVELS[$level]}}"
+    output="${output//\{TIMESTAMP\}/"${timestamp}"}"
+    output="${output//\{MESSAGE\}/"${message}"}"
+    output="${output//\{LEVEL\}/"${__BASHIO_LOG_LEVELS[$level]}"}"
 
     echo -e "${output}" >&2
 


### PR DESCRIPTION
Improper quoting causes the replacement string in the log format to be mangled. Specifically, instances of `&` in a log message will be replaced with the replacement pattern in the log format (namely: `{MESSAGE}`).

For example:

```sh
bashio::log.info "FOO&BAR&BAZ"
```

produces:

```
[08:17:56] INFO: FOO{MESSAGE}BAR{MESSAGE}BAZ
```

although one would expect it to produce:

```
[08:17:56] INFO: FOO&BAR&BAZ
```

This PR quotes the replacement strings so that the `&` character is treated as a literal character by bash.

---

From [the bash manual](https://www.gnu.org/software/bash/manual/bash.html#Shell-Parameter-Expansion):

> If the `patsub_replacement` shell option is enabled using `shopt`, any unquoted instances of ‘&’ in *string* are replaced with the matching portion of *pattern*. This is intended to duplicate a common `sed` idiom.

> Quoting any part of `string` inhibits replacement in the expansion of the quoted portion, including replacement strings stored in shell variables. Backslash will escape ‘`&`’ in `string`; the backslash is removed in order to permit a literal ‘`&`’ in the replacement string. Users should take care if `string` is double-quoted to avoid unwanted interactions between the backslash and double-quoting, since backslash has special meaning within double quotes. Pattern substitution performs the check for unquoted ‘`&`’ after expanding `string`, so users should ensure to properly quote any occurrences of ‘`&`’ they want to be taken literally in the replacement and ensure any instances of ‘`&`’ they want to be replaced are unquoted.
