### PR TITLE
Fix arguments for sourced script

### DIFF
--- a/lib/bashio
+++ b/lib/bashio
@@ -22,5 +22,7 @@ __BASHIO_LIB_DIR=$(dirname "${__BASHIO_BIN}")
 source "${__BASHIO_LIB_DIR}/bashio.sh"
 
 # Execute source
+BASH_ARGV0=${1:?script to source must be provided}
+shift
 # shellcheck source=/dev/null
-source "$@"
+source "$0" "$@"


### PR DESCRIPTION
Quality of life improvement for handling arguments, mostly useful for testing things on the command line.

# Proposed Changes

Shifts around the arguments (and sets argv[0] to the target script) so that they would be as you expect if the call at the end of `bashio` was `exec "$@"` instead of `source "$@"`.

From the [bash manual](https://www.gnu.org/software/bash/manual/bash.html#Bourne-Shell-Builtins):

> If any `arguments` are supplied, they become the positional parameters when `filename` is executed. Otherwise the positional parameters are unchanged.

This makes handling arguments annoying, because there's no way other than testing `[[ $1 = $EXPECTED_SCRIPT_PATH ]]` to see if arguments were passed on the command line. And if arguments are passed, there's no way to access the true script's path

## Example

given `example.sh`:

```sh
#!/command/with-contenv bashio

bashio::log.info "0='${0}'"
bashio::log.info "1='${1:-NONE}'"
bashio::log.info "2='${2:-NONE}'"

exec /bin/echo "$@"
```

prior to change:

```sh
$ /example.sh
[23:21:36] INFO: 0='/usr/bin/bashio'
[23:21:36] INFO: 1='/example.sh'
[23:21:36] INFO: 2='NONE'
/example.sh
```

```sh
$ /example.sh foo bar
[23:21:39] INFO: 0='/usr/bin/bashio'
[23:21:39] INFO: 1='foo'
[23:21:39] INFO: 2='bar'
foo bar
```

after change:

```sh
$ /example.sh
[23:21:47] INFO: 0='/example.sh'
[23:21:47] INFO: 1='NONE'
[23:21:47] INFO: 2='NONE'
```

```sh
$ /example.sh foo bar
[23:21:51] INFO: 0='/example.sh'
[23:21:51] INFO: 1='foo'
[23:21:51] INFO: 2='bar'
foo bar
```
