### PR TITLE
Fix exit code when calling supervisor api with raw=true

### DIFF
--- a/lib/api.sh
+++ b/lib/api.sh
@@ -93,7 +93,7 @@ function bashio::api.supervisor() {
 
     if bashio::var.true "${raw}"; then
         echo "${response}"
-        return "${__BASHIO_EXIT_NOK}"
+        return "${__BASHIO_EXIT_OK}"
     fi
 
     result=$(bashio::jq "${response}" 'if .data == {} then empty else .data end')


### PR DESCRIPTION
No reason this should fail, AFAICT. In fact, it makes it hard to detect if there are any HTTP errors.