### PR TITLE
Fix typo in var.true() and var.false() documentation

### DIFF
--- a/lib/var.sh
+++ b/lib/var.sh
@@ -8,7 +8,7 @@
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
-# Checks if a give value is true.
+# Checks if a given value is true.
 #
 # Arguments:
 #   $1 value
@@ -26,7 +26,7 @@ function bashio::var.true() {
 }
 
 # ------------------------------------------------------------------------------
-# Checks if a give value is false.
+# Checks if a given value is false.
 #
 # Arguments:
 #   $1 value


### PR DESCRIPTION
# Proposed Changes

Fix minor typos in documentation

## Related Issues

There are none

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
