### PR TITLE
Fix duplicated bashio::network.enabled() function

### DIFF
--- a/lib/network.sh
+++ b/lib/network.sh
@@ -164,7 +164,7 @@ function bashio::network.enabled() {
 # Arguments:
 #   $1 Interface name for this operation (optional)
 # ------------------------------------------------------------------------------
-function bashio::network.enabled() {
+function bashio::network.connected() {
     local interface=${1:-'default'}
 
     bashio::log.trace "${FUNCNAME[0]}"


### PR DESCRIPTION
The documenation says it's about whether there is a connection

# Proposed Changes

Fixes the duplicated bashio::network.enabled() where bashio::network.connected() was intended.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
