### PR TITLE
Avoid caching when API call fails

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -164,6 +164,10 @@ function bashio::addons() {
             info=$(bashio::cache.get 'addons.list')
         else
             info=$(bashio::api.supervisor GET "/addons" false)
+            if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+                bashio::log.error "Failed to get addons from Supervisor API"
+                return "${__BASHIO_EXIT_NOK}"
+            fi
             bashio::cache.set "addons.list" "${info}"
         fi
     else
@@ -171,6 +175,10 @@ function bashio::addons() {
             info=$(bashio::cache.get "addons.${slug}.info")
         else
             info=$(bashio::api.supervisor GET "/addons/${slug}/info" false)
+            if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+                bashio::log.error "Failed to get addon info from Supervisor API"
+                return "${__BASHIO_EXIT_NOK}"
+            fi
             bashio::cache.set "addons.${slug}.info" "${info}"
         fi
     fi
@@ -1202,6 +1210,10 @@ function bashio::addon.stats() {
         info=$(bashio::cache.get "addons.${slug}.stats")
     else
         info=$(bashio::api.supervisor GET "/addons/${slug}/stats" false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get addon stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set "addons.${slug}.stats" "${info}"
     fi
 

--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -77,6 +77,10 @@ function bashio::audio() {
         info=$(bashio::cache.get 'audio.info')
     else
         info=$(bashio::api.supervisor GET /audio/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get audio info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'audio.info' "${info}"
     fi
 
@@ -147,6 +151,10 @@ function bashio::audio.stats() {
         info=$(bashio::cache.get 'audio.stats')
     else
         info=$(bashio::api.supervisor GET /audio/stats false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get audio stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'audio.stats' "${info}"
     fi
 

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -51,6 +51,10 @@ function bashio::cli() {
         info=$(bashio::cache.get 'cli.info')
     else
         info=$(bashio::api.supervisor GET /cli/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get cli info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'cli.info' "${info}"
     fi
 
@@ -113,6 +117,10 @@ function bashio::cli.stats() {
         info=$(bashio::cache.get 'cli.stats')
     else
         info=$(bashio::api.supervisor GET /cli/stats false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get cli stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'cli.stats' "${info}"
     fi
 

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -99,6 +99,10 @@ function bashio::core() {
         info=$(bashio::cache.get 'core.info')
     else
         info=$(bashio::api.supervisor GET /core/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get core info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'core.info' "${info}"
     fi
 
@@ -249,6 +253,10 @@ function bashio::core.stats() {
         info=$(bashio::cache.get 'core.stats')
     else
         info=$(bashio::api.supervisor GET /core/stats false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get core stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'core.stats' "${info}"
     fi
 

--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -77,6 +77,10 @@ function bashio::dns() {
         info=$(bashio::cache.get 'dns.info')
     else
         info=$(bashio::api.supervisor GET /dns/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get dns info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'dns.info' "${info}"
     fi
 
@@ -163,6 +167,10 @@ function bashio::dns.stats() {
         info=$(bashio::cache.get 'dns.stats')
     else
         info=$(bashio::api.supervisor GET /dns/stats false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get dns stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'dns.stats' "${info}"
     fi
 

--- a/lib/hardware.sh
+++ b/lib/hardware.sh
@@ -31,6 +31,10 @@ function bashio::hardware() {
         info=$(bashio::cache.get 'hardware.info')
     else
         info=$(bashio::api.supervisor GET /hardware/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get hardware info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'hardware.info' "${info}"
     fi
 

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -63,6 +63,10 @@ function bashio::host() {
         info=$(bashio::cache.get 'host.info')
     else
         info=$(bashio::api.supervisor GET /host/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get host info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'host.info' "${info}"
     fi
 

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -31,6 +31,10 @@ function bashio::info() {
         info=$(bashio::cache.get 'info')
     else
         info=$(bashio::api.supervisor GET /info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'info' "${info}"
     fi
 

--- a/lib/multicast.sh
+++ b/lib/multicast.sh
@@ -68,6 +68,10 @@ function bashio::multicast() {
         info=$(bashio::cache.get 'multicast.info')
     else
         info=$(bashio::api.supervisor GET /multicast/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get multicast info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'multicast.info' "${info}"
     fi
 
@@ -130,6 +134,10 @@ function bashio::multicast.stats() {
         info=$(bashio::cache.get 'multicast.stats')
     else
         info=$(bashio::api.supervisor GET /multicast/stats false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get multicast stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'multicast.stats' "${info}"
     fi
 

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -41,6 +41,10 @@ function bashio::network() {
         info=$(bashio::cache.get 'network.info')
     else
         info=$(bashio::api.supervisor GET /network/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get network info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'network.info' "${info}"
     fi
 
@@ -105,6 +109,10 @@ function bashio::network.interface() {
         info=$(bashio::cache.get "network.interface.${interface}.info")
     else
         info=$(bashio::api.supervisor GET "/network/interface/${interface}/info" false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get network interface info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set "network.interface.${interface}.info" "${info}"
     fi
 

--- a/lib/observer.sh
+++ b/lib/observer.sh
@@ -51,6 +51,10 @@ function bashio::observer() {
         info=$(bashio::cache.get 'observer.info')
     else
         info=$(bashio::api.supervisor GET /observer/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get observer info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'observer.info' "${info}"
     fi
 
@@ -121,6 +125,10 @@ function bashio::observer.stats() {
         info=$(bashio::cache.get 'observer.stats')
     else
         info=$(bashio::api.supervisor GET /observer/stats false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get observer stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'observer.stats' "${info}"
     fi
 

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -59,6 +59,10 @@ function bashio::os() {
         info=$(bashio::cache.get 'os.info')
     else
         info=$(bashio::api.supervisor GET /os/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get os info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'os.info' "${info}"
     fi
 

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -34,6 +34,10 @@ function bashio::repositories() {
             info=$(bashio::cache.get 'repositories.list')
         else
             info=$(bashio::api.supervisor GET "/addons" false)
+            if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+                bashio::log.error "Failed to get addons from Supervisor API"
+                return "${__BASHIO_EXIT_NOK}"
+            fi
             bashio::cache.set "repositories.list" "${info}"
         fi
     else
@@ -42,6 +46,10 @@ function bashio::repositories() {
         else
             info=$(bashio::api.supervisor GET "/addons" \
                     false ".repositories[] | select(.slug==\"${slug}\")")
+            if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+                bashio::log.error "Failed to get repositories info from Supervisor API"
+                return "${__BASHIO_EXIT_NOK}"
+            fi
             bashio::cache.set "repositories.${slug}.info" "${info}"
         fi
     fi

--- a/lib/services.sh
+++ b/lib/services.sh
@@ -28,6 +28,10 @@ function bashio::services() {
         config=$(bashio::cache.get "${cache_key}")
     else
         config=$(bashio::api.supervisor GET "/services/${service}" false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get services from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set "${cache_key}" "${config}"
     fi
 

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -76,6 +76,10 @@ function bashio::supervisor() {
         info=$(bashio::cache.get 'supervisor.info')
     else
         info=$(bashio::api.supervisor GET /supervisor/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get supervisor info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'supervisor.info' "${info}"
     fi
 
@@ -314,6 +318,10 @@ function bashio::supervisor.stats() {
         info=$(bashio::cache.get 'supervisor.stats')
     else
         info=$(bashio::api.supervisor GET /supervisor/stats false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get supervisor stats from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         bashio::cache.set 'supervisor.stats' "${info}"
     fi
 


### PR DESCRIPTION
# Proposed Changes

Check the return code of the bash function call and only store the result in the cache if the call was successful. This avoids caching empty values.

## Related Issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced error handling across multiple system info retrieval functions to properly report failures and prevent processing of invalid data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->