### PR TITLE
Add Supervisor country

### DIFF
--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -183,6 +183,26 @@ function bashio::supervisor.timezone() {
 }
 
 # ------------------------------------------------------------------------------
+# Returns or sets the current country of the system.
+#
+# Arguments:
+#   $1 Country to set (optional).
+# ------------------------------------------------------------------------------
+function bashio::supervisor.country() {
+    local country=${1:-}
+
+    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+
+    if bashio::var.has_value "${country}"; then
+        channel=$(bashio::var.json country "${country}")
+        bashio::api.supervisor POST /supervisor/options "${country}"
+        bashio::cache.flush_all
+    else
+        bashio::supervisor 'supervisor.info.country' '.country'
+    fi
+}
+
+# ------------------------------------------------------------------------------
 # Returns the current logging level of the Supervisor.
 #
 # Arguments:


### PR DESCRIPTION
# Proposed Changes

Add support to read the installations Country as known by Supervisor.

See: https://github.com/home-assistant/supervisor/pull/5826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to get or set the current country of the system through a new command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->