### PR TITLE
Avoid caching when add-on config API call fails

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -545,7 +545,7 @@ function bashio::addon.option() {
     else
       options=$(bashio::jq "${options}" "del(.${key})")
     fi
-    
+
     payload=$(bashio::var.json options "^${options}")
     bashio::api.supervisor POST "/addons/${slug}/options" "${payload}"
 
@@ -569,6 +569,10 @@ function bashio::addon.config() {
     fi
 
     response=$(bashio::api.supervisor GET "/addons/self/options/config" false)
+    if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+        bashio::log.error "Failed to get addon config from Supervisor API"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
 
     # If the add-on has no configuration, it returns an empty string.
     # This is Bashio logic, that is problematic in this case, so make it a


### PR DESCRIPTION
# Proposed Changes

In #164 this location was missed.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when retrieving add-on configuration, providing clearer error messages if the operation fails.
  * Removed unnecessary trailing whitespace for cleaner output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->