### PR TITLE
Use stdout for logging output

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -15,7 +15,7 @@
 # ------------------------------------------------------------------------------
 bashio::log() {
     local message=$*
-    echo -e "${message}" >&2
+    echo -e "${message}"
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -27,7 +27,7 @@ bashio::log() {
 # ------------------------------------------------------------------------------
 bashio::log.red() {
     local message=$*
-    echo -e "${__BASHIO_COLORS_RED}${message}${__BASHIO_COLORS_RESET}" >&2
+    echo -e "${__BASHIO_COLORS_RED}${message}${__BASHIO_COLORS_RESET}"
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -39,7 +39,7 @@ bashio::log.red() {
 # ------------------------------------------------------------------------------
 bashio::log.green() {
     local message=$*
-    echo -e "${__BASHIO_COLORS_GREEN}${message}${__BASHIO_COLORS_RESET}" >&2
+    echo -e "${__BASHIO_COLORS_GREEN}${message}${__BASHIO_COLORS_RESET}"
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -51,7 +51,7 @@ bashio::log.green() {
 # ------------------------------------------------------------------------------
 bashio::log.yellow() {
     local message=$*
-    echo -e "${__BASHIO_COLORS_YELLOW}${message}${__BASHIO_COLORS_RESET}" >&2
+    echo -e "${__BASHIO_COLORS_YELLOW}${message}${__BASHIO_COLORS_RESET}"
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -63,7 +63,7 @@ bashio::log.yellow() {
 # ------------------------------------------------------------------------------
 bashio::log.blue() {
     local message=$*
-    echo -e "${__BASHIO_COLORS_BLUE}${message}${__BASHIO_COLORS_RESET}" >&2
+    echo -e "${__BASHIO_COLORS_BLUE}${message}${__BASHIO_COLORS_RESET}"
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -75,7 +75,7 @@ bashio::log.blue() {
 # ------------------------------------------------------------------------------
 bashio::log.magenta() {
     local message=$*
-    echo -e "${__BASHIO_COLORS_MAGENTA}${message}${__BASHIO_COLORS_RESET}" >&2
+    echo -e "${__BASHIO_COLORS_MAGENTA}${message}${__BASHIO_COLORS_RESET}"
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -87,7 +87,7 @@ bashio::log.magenta() {
 # ------------------------------------------------------------------------------
 bashio::log.cyan() {
     local message=$*
-    echo -e "${__BASHIO_COLORS_CYAN}${message}${__BASHIO_COLORS_RESET}" >&2
+    echo -e "${__BASHIO_COLORS_CYAN}${message}${__BASHIO_COLORS_RESET}"
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -115,7 +115,7 @@ function bashio::log.log() {
     output="${output//\{MESSAGE\}/"${message}"}"
     output="${output//\{LEVEL\}/"${__BASHIO_LOG_LEVELS[$level]}"}"
 
-    echo -e "${output}" >&2
+    echo -e "${output}"
 
     return "${__BASHIO_EXIT_OK}"
 }


### PR DESCRIPTION
# Proposed Changes

Use stdout instead of stderr for outputting messages. While using stderr is default e.g. in Python as well, using it for add-ons makes the logs in Home Assistant OS (which uses Docker with journald log driver) to be logged with err priority (level 3) to the Systemd Journal.

Moreover, as a result of using different pipe than stdout, mixing standard output (e.g. echo commands) with bashio logging might result in the add-on output being printed out of order once the pipes are printed next to each other, unless the output has been printed to stderr as well. This can cause confusion, as seen in #154.

## Related Issues

- #154

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
