### PR TITLE
Fix unbound variable in log initialization

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -8,7 +8,7 @@
 # ==============================================================================
 
 # Unless $LOG_FD is already set to a valid fd
-if ! [[ "$LOG_FD" =~ ^[0-9]+$ ]] || ! { true >&"$LOG_FD" ; } 2>/dev/null ; then
+if ! [[ "${LOG_FD-}" =~ ^[0-9]+$ ]] || ! { : >&"${LOG_FD-2}"; } 2>/dev/null; then
   # Preserve the original STDOUT on a free fd (stored in $LOG_FD) so that we can
   # log to it without interfering with the STDOUT of subshells whose output we
   # want to capture for other purposes.


### PR DESCRIPTION
# Proposed Changes

With #172 we've added `LOG_FD` as variable to redirect log messages to. The safety changes turned out to be problematic since we run the shell with `set -u` (or `nounset`). Use parameter expansion to avoid accessing the unbound variable.

## Related Issues

https://github.com/hassio-addons/addon-base/issues/343


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging setup reliability, preventing failures when a custom log file descriptor is unset or unavailable.
  * Ensures stdout redirection for logging behaves consistently and avoids noisy error output in edge cases.
  * Reduces risk of startup issues in scripts that rely on logging.

* **Refactor**
  * Simplified internal validation and redirection logic with no change to user-facing behavior or defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->