### PR TITLE
New function to redirect the $LOG_FD fd to a changed STDOUT

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -16,6 +16,21 @@ if ! [[ "${LOG_FD-}" =~ ^[0-9]+$ ]] || ! { : >&"${LOG_FD-2}"; } 2>/dev/null; the
 fi
 
 # ------------------------------------------------------------------------------
+# Redirects the $LOG_FD fd to a changed STDOUT.
+#
+# If an add-on script changed the STDOUT (after the $LOG_FD fd was redirected to
+# it, see above), this function redirects the $LOG_FD fd to the new STDOUT.
+#
+# Add-on developers must call this function after changing the STDOUT if they
+# want the log functions to log to the new STDOUT.
+# ------------------------------------------------------------------------------
+function bashio::log.reinitialize_output() {
+    if [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]]; then
+        eval "exec ${LOG_FD}>&1"
+    fi
+}
+
+# ------------------------------------------------------------------------------
 # Log a message to output.
 #
 # Arguments:

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -25,7 +25,7 @@ fi
 # want the log functions to log to the new STDOUT.
 # ------------------------------------------------------------------------------
 function bashio::log.reinitialize_output() {
-    if [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]]; then
+    if [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]] && { : >&"${LOG_FD}"; } 2>/dev/null; then
         eval "exec ${LOG_FD}>&1"
     fi
 }


### PR DESCRIPTION
# Proposed Changes

Based on my comment in #174 (https://github.com/hassio-addons/bashio/pull/174#issuecomment-3494223123)

This is useful in scripts that are not called by S6 and have their STDOUT and STDERR not initialized (ie. redirected to /dev/null) and they have to redirect their STDOUT and STDERR to eg. /proc/1/fd/1. This is valid for eg. Docker healthcheck scripts, some daemons started by S6 services (eg. in case of NetworkManager dispatcher only STDERR has valid value, but crond scripts are started with valid STDOUT and STDERR).

Possible enhancements:

1. Maybe we can extend it with adding `exec &>/proc/1/fd/1` before/outside the `if`? Add-on scripts can log/write only here. In this case this would be a general reinitialization for scripts not started by S6. This would be a useful addition.

1. Or we can hide this function completely: if the shebang references bashio, bashio checks that STDOUT and STDERR has valid, non /dev/null values, and if any of them is /dev/null, redirects them to /proc/1/fd/1 automatically? This can be a breaking change for some corner cases.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to reinitialize logging output so log messages can be redirected to the current standard output. This ensures logs remain visible and correctly routed after external changes to output streams, improving reliability of logging across scripts and runtime adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->