### PR TITLE
Add missing bashio::addon.ingress_panel() function

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -1193,12 +1193,7 @@ function bashio::addon.ingress_panel() {
     if bashio::var.has_value "${ingress_panel}"; then
         ingress_panel=$(bashio::var.json ingress_panel "^${ingress_panel}")
         bashio::api.supervisor POST "/addons/${slug}/options" "${ingress_panel}"
-        local exit_status="$?"
         bashio::cache.flush_all
-        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
-            bashio::log.error "Failed to access addon info on Supervisor API"
-            return "${__BASHIO_EXIT_NOK}"
-        fi
     else
         bashio::addons \
             "${slug}" \

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -1193,7 +1193,12 @@ function bashio::addon.ingress_panel() {
     if bashio::var.has_value "${ingress_panel}"; then
         ingress_panel=$(bashio::var.json ingress_panel "^${ingress_panel}")
         bashio::api.supervisor POST "/addons/${slug}/options" "${ingress_panel}"
+        local exit_status="$?"
         bashio::cache.flush_all
+        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to access addon info on Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
     else
         bashio::addons \
             "${slug}" \

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -1178,6 +1178,31 @@ function bashio::addon.ingress_port() {
 }
 
 # ------------------------------------------------------------------------------
+# Returns or sets whether or not ingress_panel is enabled for this add-on.
+#
+# Arguments:
+#   $1 Add-on slug (optional, default: self)
+#   $2 Set current ingress_panel state (Optional)
+# ------------------------------------------------------------------------------
+function bashio::addon.ingress_panel() {
+    local slug=${1:-'self'}
+    local ingress_panel=${2:-}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::var.has_value "${ingress_panel}"; then
+        ingress_panel=$(bashio::var.json ingress_panel "^${ingress_panel}")
+        bashio::api.supervisor POST "/addons/${slug}/options" "${ingress_panel}"
+        bashio::cache.flush_all
+    else
+        bashio::addons \
+            "${slug}" \
+            "addons.${slug}.ingress_panel" \
+            '.ingress_panel // false'
+    fi
+}
+
+# ------------------------------------------------------------------------------
 # Returns or sets whether or not watchdog is enabled for this add-on.
 #
 # Arguments:


### PR DESCRIPTION
# Proposed Changes

Tested, works.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add-ons can now remotely read and update ingress panel settings, optionally targeting a specific add-on, with changes applied immediately for more flexible panel configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->