### PR TITLE
Fix bashio::repositories() and bashio::addons() due to Supervisor API changes

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -61,7 +61,7 @@ function bashio::addon.stop() {
 function bashio::addon.install() {
     local slug=${1}
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::api.supervisor POST "/addons/${slug}/install"
+    bashio::api.supervisor POST "/store/addons/${slug}/install"
 }
 
 # ------------------------------------------------------------------------------
@@ -97,7 +97,7 @@ function bashio::addon.uninstall() {
 function bashio::addon.update() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::api.supervisor POST "/addons/${slug}/update"
+    bashio::api.supervisor POST "/store/addons/${slug}/update"
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -223,7 +223,7 @@ function bashio::addons() {
 
 # ------------------------------------------------------------------------------
 # Returns a list of installed add-ons or for a specific add-ons.
-
+#
 # Arguments:
 #   $1 Add-on slug (optional)
 # ------------------------------------------------------------------------------

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -270,7 +270,7 @@ function bashio::addon.installed() {
 # Returns the slug of the current (self) add-on.
 # ------------------------------------------------------------------------------
 function bashio::addon.slug() {
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    bashio::log.trace "${FUNCNAME[0]}"
     bashio::addons 'self' 'addons.self.slug' '.slug'
 }
 

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -246,7 +246,7 @@ function bashio::addons.installed() {
 # ------------------------------------------------------------------------------
 function bashio::addons.repositories() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::addons 'addons.info.repositories' '.repositories[]'
+    bashio::addons false 'addons.info.repositories' '.repositories[]'
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -62,6 +62,7 @@ function bashio::addon.install() {
     local slug=${1}
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor POST "/store/addons/${slug}/install"
+    bashio::cache.flush_all
 }
 
 # ------------------------------------------------------------------------------
@@ -86,6 +87,7 @@ function bashio::addon.uninstall() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor POST "/addons/${slug}/uninstall"
+    bashio::cache.flush_all
 }
 
 # ------------------------------------------------------------------------------
@@ -98,6 +100,7 @@ function bashio::addon.update() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor POST "/store/addons/${slug}/update"
+    bashio::cache.flush_all
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -112,7 +112,6 @@ function bashio::addon.logs() {
     bashio::api.supervisor GET "/addons/${slug}/logs" true
 }
 
-
 # ------------------------------------------------------------------------------
 # Returns the documentation of the add-on.
 #
@@ -120,7 +119,8 @@ function bashio::addon.logs() {
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.documentation() {
-    local slug=${1:-'self'}
+    # This call is redirected to the store, and store doesn't support 'self'
+    local slug=${1:-$(bashio::addon.slug)}
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor GET "/addons/${slug}/documentation" true
 }
@@ -132,7 +132,8 @@ function bashio::addon.documentation() {
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.changelog() {
-    local slug=${1:-'self'}
+    # This call is redirected to the store, and store doesn't support 'self'
+    local slug=${1:-$(bashio::addon.slug)}
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor GET "/addons/${slug}/changelog" true
 }
@@ -259,6 +260,18 @@ function bashio::addon.installed() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
     # when info is coming from store API, .installed is always false, when data is coming from addons API, .installed is null
     bashio::addons "${slug}" "addons.${slug}.installed" "if (.installed != null) then .installed else true end"
+}
+
+# ------------------------------------------------------------------------------
+# Returns the slug of an add-on.
+#
+# Arguments:
+#   $1 Add-on slug (optional, default: self)
+# ------------------------------------------------------------------------------
+function bashio::addon.slug() {
+    local slug=${1:-'self'}
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    bashio::addons "${slug}" "addons.${slug}.slug" '.slug'
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -97,7 +97,7 @@ function bashio::addon.uninstall() {
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.update() {
-    local slug=${1:-'self'}
+    local slug=${1:-$(bashio::addon.slug)}
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor POST "/store/addons/${slug}/update"
     bashio::cache.flush_all

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -267,15 +267,11 @@ function bashio::addon.installed() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns the slug of an add-on.
-#
-# Arguments:
-#   $1 Add-on slug (optional, default: self)
+# Returns the slug of the current (self) add-on.
 # ------------------------------------------------------------------------------
 function bashio::addon.slug() {
-    local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons "${slug}" "addons.${slug}.slug" '.slug'
+    bashio::addons 'self' 'addons.self.slug' '.slug'
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -196,6 +196,7 @@ function bashio::addons() {
             if bashio::var.true "${installed}"; then
                 info_source="/addons/${slug}/info"
             else
+                # in case of unknown slug we will intentionally fail on store API access
                 info_source="/store/addons/${slug}"
             fi
 
@@ -252,7 +253,8 @@ function bashio::addons.installed() {
 function bashio::addon.installed() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons "${slug}" "addons.${slug}.installed" "if (.installed != null) then false else true end"
+    # when info is coming from store API, .installed is always false, when data is coming from addons API, .installed is null
+    bashio::addons "${slug}" "addons.${slug}.installed" "if (.installed != null) then .installed else true end"
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -217,6 +217,10 @@ function bashio::addons() {
     response="${info}"
     if ! bashio::var.false "${filter}"; then
         response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         if ! bashio::var.false "${cache_key}"; then
             bashio::cache.set "${cache_key}" "${response}"
         fi

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -192,7 +192,11 @@ function bashio::addons() {
         if bashio::cache.exists "addons.${slug}.info"; then
             info=$(bashio::cache.get "addons.${slug}.info")
         else
-            installed=$(bashio::jq "${info}" ".addons[] | select(.slug == \"${slug}\") | .installed")
+            if bashio::var.equals "${slug}" "self"; then
+                installed=true
+            else
+                installed=$(bashio::jq "${info}" ".addons[] | select(.slug == \"${slug}\") | .installed")
+            fi
             if bashio::var.true "${installed}"; then
                 info_source="/addons/${slug}/info"
             else

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -70,7 +70,7 @@ function bashio::repositories() {
     if ! bashio::var.false "${filter}"; then
         response=$(bashio::jq "${info}" "${filter}")
         if ! bashio::var.false "${cache_key}"; then
-          bashio::cache.set "${cache_key}" "${response}"
+            bashio::cache.set "${cache_key}" "${response}"
         fi
     fi
 

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -142,8 +142,13 @@ function bashio::repository.add() {
 
     repository=$(bashio::var.json repository "${repository}")
     bashio::api.supervisor POST "/store/repositories" "${repository}"
+    if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+        bashio::log.error "Failed to post repository info to Supervisor API"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
 
     bashio::cache.flush_all
+    return "${__BASHIO_EXIT_OK}"
 }
 
 # ------------------------------------------------------------------------------
@@ -157,7 +162,13 @@ function bashio::repository.delete() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "DELETE" "/store/repositories/${slug}"
+    if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+        bashio::log.error "Failed to post repository info to Supervisor API"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
     bashio::cache.flush_all
+    return "${__BASHIO_EXIT_OK}"
 }
 
 # ------------------------------------------------------------------------------
@@ -171,5 +182,11 @@ function bashio::repository.repair() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "POST" "/store/repositories/${slug}/repair"
+    if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+        bashio::log.error "Failed to post repository info to Supervisor API"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
     bashio::cache.flush_all
+    return "${__BASHIO_EXIT_OK}"
 }

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -12,7 +12,7 @@
 #
 # Arguments:
 #   $1 Repository slug (optional)
-#     (default/empty/'false' for all add-ons)
+#     (default/empty/'false' for all repositories)
 #   $2 Cache key to store filtered results in (optional)
 #     (default/empty/'false' to cache only unfiltered results)
 #   $3 jq filter to apply on the result (optional)

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -54,6 +54,7 @@ function bashio::repositories() {
                 bashio::log.error "Failed to get repositories from Supervisor API"
                 return "${__BASHIO_EXIT_NOK}"
             fi
+            bashio::cache.set "repositories.info" "${info}"
         fi
     else
         if bashio::cache.exists "repositories.${slug}.info"; then
@@ -143,7 +144,7 @@ function bashio::repository.add() {
     repository=$(bashio::var.json repository "${repository}")
     bashio::api.supervisor POST "/store/repositories" "${repository}"
     if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
-        bashio::log.error "Failed to post repository info to Supervisor API"
+        bashio::log.error "Failed to access repository on Supervisor API"
         return "${__BASHIO_EXIT_NOK}"
     fi
 
@@ -163,7 +164,7 @@ function bashio::repository.delete() {
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "DELETE" "/store/repositories/${slug}"
     if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
-        bashio::log.error "Failed to post repository info to Supervisor API"
+        bashio::log.error "Failed to access repository on Supervisor API"
         return "${__BASHIO_EXIT_NOK}"
     fi
 
@@ -183,7 +184,7 @@ function bashio::repository.repair() {
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "POST" "/store/repositories/${slug}/repair"
     if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
-        bashio::log.error "Failed to post repository info to Supervisor API"
+        bashio::log.error "Failed to access repository on Supervisor API"
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -72,6 +72,10 @@ function bashio::repositories() {
     response="${info}"
     if ! bashio::var.false "${filter}"; then
         response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         if ! bashio::var.false "${cache_key}"; then
             bashio::cache.set "${cache_key}" "${response}"
         fi

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -126,3 +126,48 @@ function bashio::repository.maintainer() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::repositories "${slug}" "repositories.${slug}.maintainer" '.maintainer'
 }
+
+# ------------------------------------------------------------------------------
+# Add an addon repository to the store.
+#
+# Arguments:
+#   $1 URL of the addon repository to add to the store.
+# ------------------------------------------------------------------------------
+function bashio::repository.add() {
+    local repository=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+
+    repository=$(bashio::var.json repository "${repository}")
+    bashio::api.supervisor POST "/store/repositories" "${repository}"
+
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Remove an unused addon repository from the store.
+#
+# Arguments:
+#   $1 Repository slug
+# ------------------------------------------------------------------------------
+function bashio::repository.delete() {
+    local slug=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::api.supervisor "DELETE" "/store/repositories/${slug}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Repair/reset an addon repository in the store that is missing or showing incorrect information.
+#
+# Arguments:
+#   $1 Repository slug
+# ------------------------------------------------------------------------------
+function bashio::repository.repair() {
+    local slug=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::api.supervisor "POST" "/store/repositories/${slug}/repair"
+    bashio::cache.flush_all
+}

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -143,13 +143,7 @@ function bashio::repository.add() {
 
     repository=$(bashio::var.json repository "${repository}")
     bashio::api.supervisor POST "/store/repositories" "${repository}"
-    local exit_status="$?"
     bashio::cache.flush_all
-    if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
-        bashio::log.error "Failed to access repository on Supervisor API"
-        return "${__BASHIO_EXIT_NOK}"
-    fi
-    return "${__BASHIO_EXIT_OK}"
 }
 
 # ------------------------------------------------------------------------------
@@ -163,13 +157,7 @@ function bashio::repository.delete() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "DELETE" "/store/repositories/${slug}"
-    local exit_status="$?"
     bashio::cache.flush_all
-    if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
-        bashio::log.error "Failed to access repository on Supervisor API"
-        return "${__BASHIO_EXIT_NOK}"
-    fi
-    return "${__BASHIO_EXIT_OK}"
 }
 
 # ------------------------------------------------------------------------------
@@ -183,11 +171,5 @@ function bashio::repository.repair() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "POST" "/store/repositories/${slug}/repair"
-    local exit_status="$?"
     bashio::cache.flush_all
-    if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
-        bashio::log.error "Failed to access repository on Supervisor API"
-        return "${__BASHIO_EXIT_NOK}"
-    fi
-    return "${__BASHIO_EXIT_OK}"
 }

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -143,12 +143,12 @@ function bashio::repository.add() {
 
     repository=$(bashio::var.json repository "${repository}")
     bashio::api.supervisor POST "/store/repositories" "${repository}"
-    if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+    local exit_status="$?"
+    bashio::cache.flush_all
+    if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
         bashio::log.error "Failed to access repository on Supervisor API"
         return "${__BASHIO_EXIT_NOK}"
     fi
-
-    bashio::cache.flush_all
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -163,12 +163,12 @@ function bashio::repository.delete() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "DELETE" "/store/repositories/${slug}"
-    if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+    local exit_status="$?"
+    bashio::cache.flush_all
+    if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
         bashio::log.error "Failed to access repository on Supervisor API"
         return "${__BASHIO_EXIT_NOK}"
     fi
-
-    bashio::cache.flush_all
     return "${__BASHIO_EXIT_OK}"
 }
 
@@ -183,11 +183,11 @@ function bashio::repository.repair() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
     bashio::api.supervisor "POST" "/store/repositories/${slug}/repair"
-    if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+    local exit_status="$?"
+    bashio::cache.flush_all
+    if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
         bashio::log.error "Failed to access repository on Supervisor API"
         return "${__BASHIO_EXIT_NOK}"
     fi
-
-    bashio::cache.flush_all
     return "${__BASHIO_EXIT_OK}"
 }

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -26,6 +26,9 @@ function bashio::repositories() {
     if bashio::var.is_empty "${filter}"; then
         if bashio::var.false "${slug}"; then
             filter='.[].slug'
+            if bashio::var.false "${cache_key}"; then
+                cache_key="repositories.list"
+            fi
         else
             filter='.slug'
         fi
@@ -35,23 +38,22 @@ function bashio::repositories() {
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
-    if ! bashio::var.false "${cache_key}" \
-        && bashio::cache.exists "${cache_key}"
+    if ! bashio::var.false "${cache_key}" && \
+        bashio::cache.exists "${cache_key}"
     then
         bashio::cache.get "${cache_key}"
         return "${__BASHIO_EXIT_OK}"
     fi
 
     if bashio::var.false "${slug}"; then
-        if bashio::cache.exists "repositories.list"; then
-            info=$(bashio::cache.get 'repositories.list')
+        if bashio::cache.exists "repositories.info"; then
+            info=$(bashio::cache.get 'repositories.info')
         else
             info=$(bashio::api.supervisor GET "/store/repositories" false)
             if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
                 bashio::log.error "Failed to get repositories from Supervisor API"
                 return "${__BASHIO_EXIT_NOK}"
             fi
-            bashio::cache.set "repositories.list" "${info}"
         fi
     else
         if bashio::cache.exists "repositories.${slug}.info"; then

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -231,26 +231,6 @@ function bashio::supervisor.ip_address() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns the time to wait after boot in seconds.
-#
-# Arguments:
-#   $1 Timezone to set (optional).
-# ------------------------------------------------------------------------------
-function bashio::supervisor.wait_boot() {
-    local wait=${1:-}
-
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
-
-    if bashio::var.has_value "${wait}"; then
-        wait=$(bashio::var.json wait_boot "${wait}")
-        bashio::api.supervisor POST /supervisor/options "${wait}"
-        bashio::cache.flush_all
-    else
-        bashio::supervisor 'supervisor.info.wait_boot' '.wait_boot'
-    fi
-}
-
-# ------------------------------------------------------------------------------
 # Returns if debug is enabled on the supervisor
 #
 # Arguments:
@@ -303,7 +283,7 @@ function bashio::supervisor.debug_block() {
 # ------------------------------------------------------------------------------
 function bashio::supervisor.addons() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::supervisor 'supervisor.info.addons' '.addons[].slug'
+    bashio::addons.installed
 }
 
 # ------------------------------------------------------------------------------
@@ -311,7 +291,7 @@ function bashio::supervisor.addons() {
 # ------------------------------------------------------------------------------
 function bashio::supervisor.addons_repositories() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::supervisor 'supervisor.info.addons_repositories' '.addons_repositories[]'
+    bashio::addons.repositories
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -282,6 +282,7 @@ function bashio::supervisor.debug_block() {
 # Returns a list of add-on slugs of the add-ons installed.
 # ------------------------------------------------------------------------------
 function bashio::supervisor.addons() {
+    # this is for backward compatibility
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::addons.installed
 }
@@ -290,8 +291,9 @@ function bashio::supervisor.addons() {
 # Returns a list of add-on repositories installed.
 # ------------------------------------------------------------------------------
 function bashio::supervisor.addons_repositories() {
+    # this is for backward compatibility
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::addons.repositories
+    bashio::repositories false "supervisor.info.addons_repositories" ".[] | {name, slug}"
 }
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Proposed Changes

This is a continuation of unmerged #176 (cc @mdegat01):
- it caches the plain slug lists when addons() is called without arguments
- updates API urls, cache keys
- handles information source properly (/store/addons or /addons), even if the repository is uninstalled
- removed bashio::addons.repositories() because bashio::supervisor.addons_repositories() calls bashio::repositories() now
- updates deprecated install and update API urls
- fixes slug=="self" for documentation() and changelog() (they are redirected to the store, and store doesn't support "self")

This is a continuation of merged #175 for repositories (cc @sairon):
- does the same things for bashio::repositories()
- it caches the plain slug lists when repositories() is called without arguments
- fixes the API urls (/addons -> /store/repositories)
- adds missing functions: add, delete, repair

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Check whether a specific add-on is installed.
  * Add, delete, and repair repositories via the store.
  * Retrieve the current add-on slug for store-aware lookups; documentation and changelogs use it by default.
  * Install/update/uninstall operations now use store-backed flows and proactively refresh cache.

* **Bug Fixes**
  * Improved caching, retrieval, filtering, and error handling for add-ons and repositories.

* **Deprecated / Removed**
  * Removed supervisor boot-wait functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->