### PR TITLE
Implement network update API for enabled, ipv4 and ipv6

### DIFF
--- a/lib/network.sh
+++ b/lib/network.sh
@@ -169,12 +169,7 @@ function bashio::network.enabled() {
     if bashio::var.has_value "${enabled}"; then
         enabled=$(bashio::var.json enabled "^${enabled}")
         bashio::api.supervisor POST "/network/interface/${interface}/update" "${enabled}"
-        local exit_status="$?"
         bashio::cache.flush_all
-        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
-            bashio::log.error "Failed to access network interface on Supervisor API"
-            return "${__BASHIO_EXIT_NOK}"
-        fi
     else
         bashio::network.interface "network.interface.${interface}.info.enabled" "${interface}" '.enabled'
     fi
@@ -313,12 +308,7 @@ function bashio::network.ipv4() {
     if bashio::var.has_value "${ipv4}"; then
         ipv4=$(bashio::var.json ipv4 "^${ipv4}")
         bashio::api.supervisor POST "/network/interface/${interface}/update" "${ipv4}"
-        local exit_status="$?"
         bashio::cache.flush_all
-        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
-            bashio::log.error "Failed to access network interface on Supervisor API"
-            return "${__BASHIO_EXIT_NOK}"
-        fi
     else
         bashio::network.interface "network.interface.${interface}.info.ipv4" "${interface}" '.ipv4'
     fi
@@ -340,12 +330,7 @@ function bashio::network.ipv6() {
     if bashio::var.has_value "${ipv6}"; then
         ipv6=$(bashio::var.json ipv6 "^${ipv6}")
         bashio::api.supervisor POST "/network/interface/${interface}/update" "${ipv6}"
-        local exit_status="$?"
         bashio::cache.flush_all
-        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
-            bashio::log.error "Failed to access network interface on Supervisor API"
-            return "${__BASHIO_EXIT_NOK}"
-        fi
     else
         bashio::network.interface "network.interface.${interface}.info.ipv6" "${interface}" '.ipv6'
     fi

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -154,16 +154,30 @@ function bashio::network.type() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns if the interface is enabled.
+# Returns or sets if the interface is enabled.
 #
 # Arguments:
 #   $1 Interface name for this operation (optional)
+#   $2 Set enabled state (Optional)
 # ------------------------------------------------------------------------------
 function bashio::network.enabled() {
     local interface=${1:-'default'}
+    local enabled=${2:-}
 
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::network.interface "network.interface.${interface}.info.enabled" "${interface}" '.enabled'
+
+    if bashio::var.has_value "${enabled}"; then
+        enabled=$(bashio::var.json enabled "^${enabled}")
+        bashio::api.supervisor POST "/network/interface/${interface}/update" "${enabled}"
+        local exit_status="$?"
+        bashio::cache.flush_all
+        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to access network interface on Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    else
+        bashio::network.interface "network.interface.${interface}.info.enabled" "${interface}" '.enabled'
+    fi
 }
 
 # ------------------------------------------------------------------------------
@@ -281,4 +295,58 @@ function bashio::network.ipv6_gateway() {
 
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::network.interface "network.interface.${interface}.info.ipv6.gateway" "${interface}" '.ipv6.gateway'
+}
+
+# ------------------------------------------------------------------------------
+# Returns or sets the ipv4 json settings of the network interfaces.
+#
+# Arguments:
+#   $1 Interface name for this operation (optional)
+#   $2 Ipv4 interface settings (Optional)
+# ------------------------------------------------------------------------------
+function bashio::network.ipv4() {
+    local interface=${1:-'default'}
+    local ipv4=${2:-}
+
+    bashio::log.trace "${FUNCNAME[0]}"
+
+    if bashio::var.has_value "${ipv4}"; then
+        ipv4=$(bashio::var.json ipv4 "^${ipv4}")
+        bashio::api.supervisor POST "/network/interface/${interface}/update" "${ipv4}"
+        local exit_status="$?"
+        bashio::cache.flush_all
+        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to access network interface on Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    else
+        bashio::network.interface "network.interface.${interface}.info.ipv4" "${interface}" '.ipv4'
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Returns or sets the ipv6 json settings of the network interfaces.
+#
+# Arguments:
+#   $1 Interface name for this operation (optional)
+#   $2 Ipv6 interface settings (Optional)
+# ------------------------------------------------------------------------------
+function bashio::network.ipv6() {
+    local interface=${1:-'default'}
+    local ipv6=${2:-}
+
+    bashio::log.trace "${FUNCNAME[0]}"
+
+    if bashio::var.has_value "${ipv6}"; then
+        ipv6=$(bashio::var.json ipv6 "^${ipv6}")
+        bashio::api.supervisor POST "/network/interface/${interface}/update" "${ipv6}"
+        local exit_status="$?"
+        bashio::cache.flush_all
+        if [ "${exit_status}" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to access network interface on Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    else
+        bashio::network.interface "network.interface.${interface}.info.ipv6" "${interface}" '.ipv6'
+    fi
 }


### PR DESCRIPTION
# Proposed Changes

Based on https://developers.home-assistant.io/docs/api/supervisor/endpoints/#network

Changing enabled option is trivial.

New IPv4 and IPv6 functions use JSON for input/output: I've experimented with it, and even the docs says that all the fields are optional, in reality we have to specify eg. address, nameservers and gateway together. So it makes sense to get them in a JSON struct (not only with the current individual get functions), and setting them with JSON is way more simple then coding one-by-one, and AFAIK this is the standard around this library.

Wifi had no individual getter methods, so I didn't created a JSON get/set function for Wifi.

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Network interface status can now be configured programmatically
  * Added support for configuring IPv4 settings per network interface
  * Added support for configuring IPv6 settings per network interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->