### PR TITLE
Fix raw argument handling in Supervisor API call

### DIFF
--- a/lib/api.sh
+++ b/lib/api.sh
@@ -81,10 +81,13 @@ function bashio::api.supervisor() {
         return "${__BASHIO_EXIT_NOK}"
     fi
 
-    if ! bashio::var.true "${raw}" && [[ $(bashio::jq "${response}" ".result") = "error" ]]; then
-        bashio::log.error "Got unexpected response from the API:" \
-            "$(bashio::jq "${response}" '.message // empty')"
-        return "${__BASHIO_EXIT_NOK}"
+    if ! bashio::var.true "${raw}"; then
+        result=$(bashio::jq "${response}" ".result")
+        if bashio::var.equals "${result}" "error"; then
+            bashio::log.error "Got unexpected response from the API:" \
+                "$(bashio::jq "${response}" '.message // empty')"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
     fi
 
     if [[ "${status}" -ne 200 ]]; then

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -36,6 +36,7 @@ function bashio::api.supervisor() {
 
     if [[ "${method}" = "POST" ]] && bashio::var.has_value "${raw}"; then
         data="${raw}"
+        raw=
     fi
 
     if ! response=$(curl --silent --show-error \
@@ -80,7 +81,7 @@ function bashio::api.supervisor() {
         return "${__BASHIO_EXIT_NOK}"
     fi
 
-    if [[ $(bashio::jq "${response}" ".result") = "error" ]]; then
+    if ! bashio::var.true "${raw}" && [[ $(bashio::jq "${response}" ".result") = "error" ]]; then
         bashio::log.error "Got unexpected response from the API:" \
             "$(bashio::jq "${response}" '.message // empty')"
         return "${__BASHIO_EXIT_NOK}"

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -81,9 +81,7 @@ function bashio::api.supervisor() {
         return "${__BASHIO_EXIT_NOK}"
     fi
 
-    if ! bashio::var.true "${raw}" || \
-        bashio::jq.exists "${response}" ".result" 2> /dev/null
-    then
+    if ! bashio::var.true "${raw}"; then
         result=$(bashio::jq "${response}" ".result")
         if bashio::var.equals "${result}" "error"; then
             bashio::log.error "Got unexpected response from the API:" \

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -81,7 +81,9 @@ function bashio::api.supervisor() {
         return "${__BASHIO_EXIT_NOK}"
     fi
 
-    if ! bashio::var.true "${raw}"; then
+    if ! bashio::var.true "${raw}" || \
+        bashio::jq.exists "${response}" ".result" 2> /dev/null
+    then
         result=$(bashio::jq "${response}" ".result")
         if bashio::var.equals "${result}" "error"; then
             bashio::log.error "Got unexpected response from the API:" \


### PR DESCRIPTION
# Proposed Changes

- in case of POST, clear data from raw
- there are urls, that return non-JSON plain text content, without .result and .data, like bashio::addon.logs(), documentation(), changelog(), in those cases do not search even for the .result or .data fields

Needs #192 to be merged to function properly.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API error handling so responses are only treated as errors when appropriate to the request type.
  * Ensures raw POST payloads are cleared after use to prevent stale data from affecting subsequent requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->