### PR TITLE
Improve handling of errexit option

### DIFF
--- a/lib/bashio
+++ b/lib/bashio
@@ -10,6 +10,7 @@ set -o errexit  # Exit script when a command exits with non-zero status
 set -o errtrace # Exit on error inside any functions or sub-shells
 set -o nounset  # Exit script on use of an undefined variable
 set -o pipefail # Return exit status of the last command in the pipe that failed
+shopt -s inherit_errexit # Command substitution inherits the value of errexit
 
 export __BASHIO_BIN
 export __BASHIO_LIB_DIR

--- a/lib/bashio
+++ b/lib/bashio
@@ -10,7 +10,9 @@ set -o errexit  # Exit script when a command exits with non-zero status
 set -o errtrace # Exit on error inside any functions or sub-shells
 set -o nounset  # Exit script on use of an undefined variable
 set -o pipefail # Return exit status of the last command in the pipe that failed
-shopt -s inherit_errexit # Command substitution inherits the value of errexit
+if ! shopt -s inherit_errexit 2>/dev/null; then
+    :
+fi
 
 export __BASHIO_BIN
 export __BASHIO_LIB_DIR

--- a/lib/bashio
+++ b/lib/bashio
@@ -10,9 +10,7 @@ set -o errexit  # Exit script when a command exits with non-zero status
 set -o errtrace # Exit on error inside any functions or sub-shells
 set -o nounset  # Exit script on use of an undefined variable
 set -o pipefail # Return exit status of the last command in the pipe that failed
-if ! shopt -s inherit_errexit 2>/dev/null; then
-    :
-fi
+shopt -s inherit_errexit 2>/dev/null || true # Command substitution inherits the value of errexit when supported
 
 export __BASHIO_BIN
 export __BASHIO_LIB_DIR

--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -11,6 +11,7 @@ set -o errexit  # Exit script when a command exits with non-zero status
 set -o errtrace # Exit on error inside any functions or sub-shells
 set -o nounset  # Exit script on use of an undefined variable
 set -o pipefail # Return exit status of the last command in the pipe that failed
+shopt -s inherit_errexit # Command substitution inherits the value of errexit
 
 # ==============================================================================
 # GLOBALS
@@ -95,5 +96,7 @@ source "${__BASHIO_LIB_DIR}/string.sh"
 source "${__BASHIO_LIB_DIR}/supervisor.sh"
 # shellcheck source=lib/trace.sh
 source "${__BASHIO_LIB_DIR}/trace.sh"
+# shellcheck source=lib/try.sh
+source "${__BASHIO_LIB_DIR}/try.sh"
 # shellcheck source=lib/var.sh
 source "${__BASHIO_LIB_DIR}/var.sh"

--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -11,7 +11,7 @@ set -o errexit  # Exit script when a command exits with non-zero status
 set -o errtrace # Exit on error inside any functions or sub-shells
 set -o nounset  # Exit script on use of an undefined variable
 set -o pipefail # Return exit status of the last command in the pipe that failed
-shopt -s inherit_errexit # Command substitution inherits the value of errexit
+shopt -s inherit_errexit 2>/dev/null || true # Command substitution inherits the value of errexit when supported
 
 # ==============================================================================
 # GLOBALS

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -68,10 +68,12 @@ QUERY
 # ------------------------------------------------------------------------------
 function bashio::config.exists() {
     local key=${1}
+    local value
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
 
-    if [[ $(bashio::config "${key}") == "null" ]]; then
+    value=$(bashio::config "${key}")
+    if [[ "${value}" == "null" ]]; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -22,7 +22,7 @@ function bashio::config() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
 
-    read -r -d '' query << QUERY
+    read -r -d '' query << QUERY || true
         if (.${key} == null) then
             null
         elif (.${key} | type == "string") then

--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -37,10 +37,12 @@ function bashio::jq() {
 function bashio::jq.exists() {
     local data=${1}
     local filter=${2:-}
+    local value
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
 
-    if [[ $(bashio::jq "${data}" "${filter}") = "null" ]]; then
+    value=$(bashio::jq "${data}" "${filter}")
+    if bashio::var.equals "${value}" "null"; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 
@@ -90,7 +92,7 @@ function bashio::jq.is() {
     value=$(bashio::jq "${data}" \
         "${filter} | if type==\"${type}\" then true else false end")
 
-    if [[ "${value}" = "false" ]]; then
+    if [[ "${value}" != "true" ]]; then
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -66,7 +66,7 @@ function bashio::jq.has_value() {
 
     if ! value=$(bashio::jq "${data}" \
             "${filter} | if (. == {} or . == []) then empty else . end // empty") || \
-        || ! bashio::var.has_value "${value}"
+        ! bashio::var.has_value "${value}"
     then
         return "${__BASHIO_EXIT_NOK}"
     fi

--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -41,8 +41,9 @@ function bashio::jq.exists() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
 
-    value=$(bashio::jq "${data}" "${filter}")
-    if bashio::var.equals "${value}" "null"; then
+    if ! value=$(bashio::jq "${data}" "${filter}") || \
+        bashio::var.equals "${value}" "null"
+    then
         return "${__BASHIO_EXIT_NOK}"
     fi
 
@@ -63,10 +64,10 @@ function bashio::jq.has_value() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
 
-    value=$(bashio::jq "${data}" \
-        "${filter} | if (. == {} or . == []) then empty else . end // empty")
-
-    if ! bashio::var.has_value "${value}"; then
+    if ! value=$(bashio::jq "${data}" \
+            "${filter} | if (. == {} or . == []) then empty else . end // empty") || \
+        || ! bashio::var.has_value "${value}"
+    then
         return "${__BASHIO_EXIT_NOK}"
     fi
 
@@ -89,10 +90,10 @@ function bashio::jq.is() {
 
     bashio::log.trace "${FUNCNAME[0]}:" "$@"
 
-    value=$(bashio::jq "${data}" \
-        "${filter} | if type==\"${type}\" then true else false end")
-
-    if [[ "${value}" != "true" ]]; then
+    if ! value=$(bashio::jq "${data}" \
+            "${filter} | if type==\"${type}\" then true else false end") || \
+        [[ "${value}" != "true" ]]
+    then
         return "${__BASHIO_EXIT_NOK}"
     fi
 

--- a/lib/services.sh
+++ b/lib/services.sh
@@ -38,7 +38,7 @@ function bashio::services() {
     response="${config}"
     if bashio::var.has_value "${key}"; then
 
-        read -r -d '' query << QUERY
+        read -r -d '' query << QUERY || true
             if (.${key} == null) then
                 null
             elif (.${key} | type == "string") then

--- a/lib/try.sh
+++ b/lib/try.sh
@@ -17,7 +17,8 @@ declare __BASHIO_TRY_EXIT_STATUS=0
 #
 #
 # Use this function to get the exit status of a subshell for a condition (eg.
-# 'if') without disabling errexit option in it.
+# 'if') without disabling errexit option in it. All Bashio functions that
+# execute changes through the API are depend on enabled errexit option.
 #
 # Simple example:
 #   ~ # function test { false; echo "Don't print it"; }

--- a/lib/try.sh
+++ b/lib/try.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Add-ons: Bashio
+# Bashio is a bash function library for use with Home Assistant add-ons.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in add-on scripts to reduce code duplication across add-ons.
+# ==============================================================================
+
+declare __BASHIO_TRY_EXIT_STATUS=0
+
+# ------------------------------------------------------------------------------
+# Executes a command/function in a subshell with enabled and effective errexit
+# option and saves it's exit status.
+#
+# Arguments: $* Command/function and it's arguments
+#
+#
+# Use this function to get the exit status of a subshell for a condition (eg.
+# 'if') without disabling errexit option in it.
+#
+# Simple example:
+#   ~ # function test { false; echo "Don't print it"; }
+#   ~ # if ! test; then echo "Print it"; fi
+#   Don't print it
+#   ~ # bashio::try test
+#   ~ # if bashio::try.failed; then echo "Print it"; fi
+#   Print it
+# ------------------------------------------------------------------------------
+function bashio::try {
+    set +e
+    (set -e; "$@")
+    __BASHIO_TRY_EXIT_STATUS=$?
+    set -e
+}
+
+# ------------------------------------------------------------------------------
+# Checks whether that last command executed by bashio::try has suceeded.
+# ------------------------------------------------------------------------------
+function bashio::try.succeeded {
+    if ((__BASHIO_TRY_EXIT_STATUS)); then
+        return "${__BASHIO_EXIT_NOK}"
+    else
+        return "${__BASHIO_EXIT_OK}"
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Checks whether that last command executed by bashio::try has failed.
+# ------------------------------------------------------------------------------
+function bashio::try.failed {
+    if ((__BASHIO_TRY_EXIT_STATUS)); then
+        return "${__BASHIO_EXIT_OK}"
+    else
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+}

--- a/lib/try.sh
+++ b/lib/try.sh
@@ -18,7 +18,8 @@ declare __BASHIO_TRY_EXIT_STATUS=0
 #
 # Use this function to get the exit status of a subshell for a condition (eg.
 # 'if') without disabling errexit option in it. All Bashio functions that
-# execute changes through the API are depend on enabled errexit option.
+# execute changes through the API and do not return a response depend on enabled
+# errexit option.
 #
 # Simple example:
 #   ~ # function test { false; echo "Don't print it"; }

--- a/lib/try.sh
+++ b/lib/try.sh
@@ -11,9 +11,9 @@ declare __BASHIO_TRY_EXIT_STATUS=0
 
 # ------------------------------------------------------------------------------
 # Executes a command/function in a subshell with enabled and effective errexit
-# option and saves it's exit status.
+# option and saves its exit status.
 #
-# Arguments: $* Command/function and it's arguments
+# Arguments: $* Command/function and its arguments
 #
 #
 # Use this function to get the exit status of a subshell for a condition (eg.
@@ -37,7 +37,7 @@ function bashio::try {
 }
 
 # ------------------------------------------------------------------------------
-# Checks whether that last command executed by bashio::try has suceeded.
+# Checks whether that last command executed by bashio::try has succeeded.
 # ------------------------------------------------------------------------------
 function bashio::try.succeeded {
     if ((__BASHIO_TRY_EXIT_STATUS)); then


### PR DESCRIPTION
# Proposed Changes

The inherit_errexit option propagates and uses errexit in subshells in code like:
```
xxx=$(bashio::xxx)
```
This variable assignment is the default all over the library. Though it won't help, if the function runs in a condition (like 'if'), because errexit is propagated then, but ignored. (So the fixes below in config.sh and jq.sh has no effect, just makes variable usage consistent.)

To make it possible to call subshells with effective errexit even in conditions, I made the bashio::try() function. This is useful if somebody needs to add a condition around an API call that changes some configuration, because all of those "setter" functions assume errexit is effective.

### Some demonstrations
errexit works as expected (only 1 error message, no need for status checks):
```
➜  ~ bash
~ # source /usr/lib/bashio/bashio.sh
~ # bashio::addons foo false
[21:21:11] ERROR: Requested resource /addons/foo/info was not found
```

The additional exit status check (in all "getter" function) saves the situation:
```
➜  ~ bash
~ # source /usr/lib/bashio/bashio.sh
~ # xxx=$(bashio::addons foo false)
[21:21:58] ERROR: Requested resource /addons/foo/info was not found
[21:21:58] ERROR: Failed to get addon info from Supervisor API
```

inherit_errexit makes errexit propagated and effective in variable assignment (default in the library):
```
➜  ~ bash
~ # source /usr/lib/bashio/bashio.sh
~ # shopt -s inherit_errexit
~ # xxx=$(bashio::addons foo false)
[21:22:40] ERROR: Requested resource /addons/foo/info was not found
```

Though inherit_errexit doesn't save the situation if there is a condition (the errexit is propageted, but ignored), we need the extra status checks (if somebody uses the library without storing the values in variables first):
```
➜  ~ bash
~ # source /usr/lib/bashio/bashio.sh
~ # shopt -s inherit_errexit
~ # if ! xxx=$(bashio::addons foo false); then echo ERR; fi
[21:23:52] ERROR: Requested resource /addons/foo/info was not found
[21:23:52] ERROR: Failed to get addon info from Supervisor API
ERR
```

And nothing saves the test functions like bashio::jq.exists()

## How bashio::try helps

```
➜  ~ bash
~ # source /usr/lib/bashio/bashio.sh
~ # if ! bashio::supervisor.update "foo"; then echo ERR; fi
[22:10:18] ERROR: Got unexpected response from the API: No supervisor update available - 2026.01.1
~ #


~ # bashio::try bashio::supervisor.update "foo"
[22:23:41] ERROR: Got unexpected response from the API: No supervisor update available - 2026.01.1
~ # if bashio::try.failed; then echo ERR; fi
ERR
~ #
```


## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added helpers to run commands and check their success/failure, simplifying command execution workflows.

* **Refactor**
  * Inherited shell error behavior into subshells/command substitutions for more consistent error handling.
  * Made config and JSON reads/checks more robust by capturing results before evaluation and preventing non-critical read failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->