### PR TITLE
Add bashio::var.json_array() function

### DIFF
--- a/lib/var.sh
+++ b/lib/var.sh
@@ -179,3 +179,22 @@ function bashio::var.json_string() {
     return "${__BASHIO_EXIT_NOK}"
 }
 
+# ------------------------------------------------------------------------------
+# Converts a bash array to a JSON array.
+#
+# Arguments:
+#   $@ Bash array
+# ------------------------------------------------------------------------------
+function bashio::var.json_array() {
+    local array=("$@")
+    local json_array
+
+    # https://stackoverflow.com/a/67489301/2755656
+    if json_array=$(jq -cn '$ARGS.positional' --args -- "${array[@]}"); then
+        echo "${json_array}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    bashio::log.error "Failed to convert array"
+    return "${__BASHIO_EXIT_NOK}"
+}


### PR DESCRIPTION
# Proposed Changes

Can be used like:
```
"$(bashio::var.json \
  foo "^$(bashio::var.json_array "bar" "baz")" \
)"
```

## Related Issues



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting Bash arrays to JSON array format. The function processes array inputs and produces valid JSON output with comprehensive error handling and status codes to indicate operation success or failure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->