### PR TITLE
Harden argument handling for addon.update() .documentation() and .changelog()

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -99,7 +99,7 @@ function bashio::addon.uninstall() {
 function bashio::addon.update() {
     local slug=${1:-'self'}
     # This call is redirected to the store, and store doesn't support 'self'
-    if bashio::var.equals() "${slug}" 'self'; then
+    if bashio::var.equals "${slug}" 'self'; then
         slug=$(bashio::addon.slug)
     fi
     bashio::log.trace "${FUNCNAME[0]}"
@@ -128,7 +128,7 @@ function bashio::addon.logs() {
 function bashio::addon.documentation() {
     local slug=${1:-'self'}
     # This call is redirected to the store, and store doesn't support 'self'
-    if bashio::var.equals() "${slug}" 'self'; then
+    if bashio::var.equals "${slug}" 'self'; then
         slug=$(bashio::addon.slug)
     fi
     bashio::log.trace "${FUNCNAME[0]}"
@@ -144,7 +144,7 @@ function bashio::addon.documentation() {
 function bashio::addon.changelog() {
     local slug=${1:-'self'}
     # This call is redirected to the store, and store doesn't support 'self'
-    if bashio::var.equals() "${slug}" 'self'; then
+    if bashio::var.equals "${slug}" 'self'; then
         slug=$(bashio::addon.slug)
     fi
     bashio::log.trace "${FUNCNAME[0]}"

--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -97,7 +97,11 @@ function bashio::addon.uninstall() {
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.update() {
-    local slug=${1:-$(bashio::addon.slug)}
+    local slug=${1:-'self'}
+    # This call is redirected to the store, and store doesn't support 'self'
+    if bashio::var.equals() "${slug}" 'self'; then
+        slug=$(bashio::addon.slug)
+    fi
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor POST "/store/addons/${slug}/update"
     bashio::cache.flush_all
@@ -122,8 +126,11 @@ function bashio::addon.logs() {
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.documentation() {
+    local slug=${1:-'self'}
     # This call is redirected to the store, and store doesn't support 'self'
-    local slug=${1:-$(bashio::addon.slug)}
+    if bashio::var.equals() "${slug}" 'self'; then
+        slug=$(bashio::addon.slug)
+    fi
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor GET "/addons/${slug}/documentation" true
 }
@@ -135,8 +142,11 @@ function bashio::addon.documentation() {
 #   $1 Add-on slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.changelog() {
+    local slug=${1:-'self'}
     # This call is redirected to the store, and store doesn't support 'self'
-    local slug=${1:-$(bashio::addon.slug)}
+    if bashio::var.equals() "${slug}" 'self'; then
+        slug=$(bashio::addon.slug)
+    fi
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::api.supervisor GET "/addons/${slug}/changelog" true
 }


### PR DESCRIPTION
# Proposed Changes

Based on Copilot's reviews (https://github.com/hassio-addons/bashio/pull/187#pullrequestreview-4068454731) to handle when callers pass `self`. It makes sense to implement.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of self-referential addon operations (update, documentation, changelog). The literal "self" is now resolved at call time to the current add-on, ensuring requests target the intended add-on consistently across contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->