### PR TITLE
Make trace message formatting consistent

### DIFF
--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -16,7 +16,7 @@
 function bashio::audio.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -16,7 +16,7 @@
 function bashio::cache.exists() {
     local key=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::fs.file_exists "${__BASHIO_CACHE_DIR}/${key}.cache"; then
         return "${__BASHIO_EXIT_OK}"
@@ -34,7 +34,7 @@ function bashio::cache.exists() {
 function bashio::cache.get() {
     local key=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::cache.exists "${key}"; then
         return "${__BASHIO_EXIT_NOK}"
@@ -55,7 +55,7 @@ function bashio::cache.set() {
     local key=${1}
     local value=${2}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::fs.directory_exists "${__BASHIO_CACHE_DIR}"; then
         mkdir -p "${__BASHIO_CACHE_DIR}" ||
@@ -79,7 +79,7 @@ function bashio::cache.set() {
 function bashio::cache.flush() {
     local key=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! rm -f "${__BASHIO_CACHE_DIR}/${key}.cache"; then
         bashio::exit.nok "An error while flushing ${key} from cache"

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -16,7 +16,7 @@
 function bashio::cli.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -20,7 +20,7 @@ function bashio::config() {
     local query
     local result
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     read -r -d '' query << QUERY || true
         if (.${key} == null) then
@@ -70,7 +70,7 @@ function bashio::config.exists() {
     local key=${1}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     value=$(bashio::config "${key}")
     if [[ "${value}" == "null" ]]; then
@@ -90,7 +90,7 @@ function bashio::config.has_value() {
     local key=${1}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     value=$(bashio::config "${key}")
     if [[ "${value}" == "null" ]]; then
@@ -114,7 +114,7 @@ function bashio::config.is_empty() {
     local key=${1}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     value=$(bashio::config "${key}")
     if bashio::var.is_empty "${value}"; then
@@ -140,7 +140,7 @@ function bashio::config.equals() {
     local equals=${2}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     value=$(bashio::config "${key}")
     if ! bashio::var.equals "${value}" "${equals}"; then
@@ -160,7 +160,7 @@ function bashio::config.true() {
     local key=${1}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     value=$(bashio::config "${key}")
     if ! bashio::var.true "${value}"; then
@@ -180,7 +180,7 @@ function bashio::config.false() {
     local key=${1}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     value=$(bashio::config "${key}")
     if ! bashio::var.false "${value}"; then
@@ -200,7 +200,7 @@ function bashio::config.is_safe_password() {
     local key=${1}
     local password
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     # If the password is safe, we'll accept it anyways.
     password=$(bashio::config "${key}")
@@ -229,7 +229,7 @@ function bashio::config.require() {
     local key=${1}
     local reason=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::config.has_value "${key}"; then
         return "${__BASHIO_EXIT_OK}"
@@ -262,7 +262,7 @@ function bashio::config.suggest() {
     local key=${1}
     local reason=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::config.has_value "${key}"; then
         bashio::log.warning
@@ -294,7 +294,7 @@ function bashio::config.suggest.true() {
     local key=${1}
     local reason=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::config.true "${key}"; then
         bashio::log.warning
@@ -326,7 +326,7 @@ function bashio::config.suggest.false() {
     local key=${1}
     local reason=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::config.false "${key}"; then
         bashio::log.warning
@@ -356,7 +356,7 @@ function bashio::config.suggest.false() {
 function bashio::config.require.username() {
     local key=${1:-"username"}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::config.has_value "${key}"; then
         return "${__BASHIO_EXIT_OK}"
@@ -382,7 +382,7 @@ function bashio::config.require.username() {
 function bashio::config.suggest.username() {
     local key=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::config.has_value "${key}"; then
         bashio::log.warning
@@ -407,7 +407,7 @@ function bashio::config.suggest.username() {
 function bashio::config.require.password() {
     local key=${1:-"password"}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::config.has_value "${key}"; then
         return "${__BASHIO_EXIT_OK}"
@@ -433,7 +433,7 @@ function bashio::config.require.password() {
 function bashio::config.suggest.password() {
     local key=${1:-"password"}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::config.has_value "${key}"; then
         return "${__BASHIO_EXIT_OK}"
@@ -461,7 +461,7 @@ function bashio::config.require.safe_password() {
     local key=${1:-"password"}
     local password
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     bashio::config.require.password "${key}"
 
@@ -497,7 +497,7 @@ function bashio::config.suggest.safe_password() {
     local key=${1:-"password"}
     local password
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::config.has_value "${key}"; then
         bashio::config.suggest.password "${key}"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -48,7 +48,7 @@ function bashio::core.rebuild() {
 function bashio::core.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")
@@ -170,7 +170,7 @@ function bashio::core.machine() {
 function bashio::core.image() {
     local image=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${image}"; then
         image=$(bashio::var.json image "${image}")
@@ -222,7 +222,7 @@ function bashio::core.ssl() {
 function bashio::core.watchdog() {
     local watchdog=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${watchdog}"; then
         watchdog=$(bashio::var.json watchdog "^${watchdog}")

--- a/lib/discovery.sh
+++ b/lib/discovery.sh
@@ -19,7 +19,7 @@ function bashio::discovery() {
     local config=${2}
     local payload
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     payload=$(\
         bashio::var.json \
@@ -40,7 +40,7 @@ function bashio::discovery() {
 function bashio::discovery.delete() {
     local uuid=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::api.supervisor "DELETE" "/discovery/${uuid}"
     bashio::cache.flush_all
 }

--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -16,7 +16,7 @@
 function bashio::dns.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")

--- a/lib/exit.sh
+++ b/lib/exit.sh
@@ -16,7 +16,7 @@
 function bashio::exit.nok() {
     local message=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${message}"; then
         bashio::log.fatal "${message}"
@@ -36,7 +36,7 @@ function bashio::exit.die_if_false() {
     local value=${1:-}
     local message=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.false "${value}"; then
         bashio::exit.nok "${message}"
@@ -55,7 +55,7 @@ function hass.die_if_true() {
     local value=${1:-}
     local message=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.true "${value}"; then
         bashio::exit.nok "${message}"
@@ -73,7 +73,7 @@ function hass.die_if_empty() {
     local value=${1:-}
     local message=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.is_empty "${value}"; then
         bashio::exit.nok "${message}"

--- a/lib/fs.sh
+++ b/lib/fs.sh
@@ -16,7 +16,7 @@
 function bashio::fs.directory_exists() {
     local directory=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -d "${directory}" ]]; then
         return "${__BASHIO_EXIT_OK}"
@@ -34,7 +34,7 @@ function bashio::fs.directory_exists() {
 function bashio::fs.file_exists() {
     local file=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -f "${file}" ]]; then
         return "${__BASHIO_EXIT_OK}"
@@ -52,7 +52,7 @@ function bashio::fs.file_exists() {
 function bashio::fs.device_exists() {
     local device=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -b "${device}" || -c "${device}" ]]; then
         return "${__BASHIO_EXIT_OK}"
@@ -70,7 +70,7 @@ function bashio::fs.device_exists() {
 function bashio::fs.socket_exists() {
     local socket=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -S "${socket}" ]]; then
         return "${__BASHIO_EXIT_OK}"

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -91,7 +91,7 @@ function bashio::host() {
 function bashio::host.hostname() {
     local hostname=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${hostname}"; then
         hostname=$(bashio::var.json hostname "${hostname}")

--- a/lib/jobs.sh
+++ b/lib/jobs.sh
@@ -202,7 +202,7 @@ function bashio::job.extra() {
 function bashio::job.delete() {
     local uuid=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::api.supervisor "DELETE" "/jobs/${uuid}"
     bashio::cache.flush_all
 }

--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -18,7 +18,7 @@ function bashio::jq() {
     local data=${1}
     local filter=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -f "${data}" ]]; then
         jq --raw-output -c -M "$filter" "${data}"
@@ -39,7 +39,7 @@ function bashio::jq.exists() {
     local filter=${2:-}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! value=$(bashio::jq "${data}" "${filter}") || \
         bashio::var.equals "${value}" "null"
@@ -62,7 +62,7 @@ function bashio::jq.has_value() {
     local filter=${2:-}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! value=$(bashio::jq "${data}" \
             "${filter} | if (. == {} or . == []) then empty else . end // empty") || \
@@ -88,7 +88,7 @@ function bashio::jq.is() {
     local type=${3}
     local value
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! value=$(bashio::jq "${data}" \
             "${filter} | if type==\"${type}\" then true else false end") || \
@@ -111,7 +111,7 @@ function bashio::jq.is_boolean() {
     local data=${1}
     local filter=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::jq.is "${data}" "${filter}" "boolean"
 }
 
@@ -126,7 +126,7 @@ function bashio::jq.is_string() {
     local data=${1}
     local filter=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::jq.is "${data}" "${filter}" "string"
 }
 
@@ -141,7 +141,7 @@ function bashio::jq.is_object() {
     local data=${1}
     local filter=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::jq.is "${data}" "${filter}" "object"
 }
 
@@ -156,7 +156,7 @@ function bashio::jq.is_number() {
     local data=${1}
     local filter=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::jq.is "${data}" "${filter}" "number"
 }
 
@@ -171,6 +171,6 @@ function bashio::jq.is_array() {
     local data=${1}
     local filter=${2:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::jq.is "${data}" "${filter}" "array"
 }

--- a/lib/multicast.sh
+++ b/lib/multicast.sh
@@ -16,7 +16,7 @@
 function bashio::multicast.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")

--- a/lib/observer.sh
+++ b/lib/observer.sh
@@ -16,7 +16,7 @@
 function bashio::observer.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -16,7 +16,7 @@
 function bashio::os.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -143,7 +143,7 @@ function bashio::repository.maintainer() {
 function bashio::repository.add() {
     local repository=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     repository=$(bashio::var.json repository "${repository}")
     bashio::api.supervisor POST "/store/repositories" "${repository}"
@@ -159,7 +159,7 @@ function bashio::repository.add() {
 function bashio::repository.delete() {
     local slug=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::api.supervisor "DELETE" "/store/repositories/${slug}"
     bashio::cache.flush_all
 }
@@ -173,7 +173,7 @@ function bashio::repository.delete() {
 function bashio::repository.repair() {
     local slug=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::api.supervisor "POST" "/store/repositories/${slug}/repair"
     bashio::cache.flush_all
 }

--- a/lib/services.sh
+++ b/lib/services.sh
@@ -78,7 +78,7 @@ QUERY
 function bashio::services.available() {
     local service=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::api.supervisor GET "/services/${service}" > /dev/null 2>&1;
     then
@@ -99,7 +99,7 @@ function bashio::services.publish() {
     local service=${1}
     local config=${2}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     bashio::api.supervisor "POST" "/services/${service}" "${config}"
     bashio::cache.flush_all
@@ -114,7 +114,7 @@ function bashio::services.publish() {
 function bashio::services.delete() {
     local service=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
     bashio::api.supervisor "DELETE" "/services/${service}"
     bashio::cache.flush_all
 }

--- a/lib/string.sh
+++ b/lib/string.sh
@@ -16,7 +16,7 @@
 function bashio::string.lower() {
     local string="${1}"
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     printf "%s" "${string,,}"
 }
@@ -30,7 +30,7 @@ function bashio::string.lower() {
 function bashio::string.upper() {
     local string="${1}"
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     printf "%s" "${string^^}"
 }
@@ -48,7 +48,7 @@ function bashio::string.replace() {
     local needle="${2}"
     local replacement="${3}"
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     printf "%s" "${string//${needle}/${replacement}}"
 }
@@ -62,7 +62,7 @@ function bashio::string.replace() {
 bashio::string.length() {
     local string="${1}"
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     printf "%s" "${#string}"
 }
@@ -86,7 +86,7 @@ bashio::string.substring() {
     local position="${2}"
     local length="${3:-}"
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${length}"; then
         printf "%s" "${string:${position}:${length}}"

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -24,7 +24,7 @@ function bashio::supervisor.ping() {
 function bashio::supervisor.update() {
     local version=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")
@@ -155,7 +155,7 @@ function bashio::supervisor.healthy() {
 function bashio::supervisor.channel() {
     local channel=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${channel}"; then
         channel=$(bashio::var.json channel "${channel}")
@@ -175,7 +175,7 @@ function bashio::supervisor.channel() {
 function bashio::supervisor.timezone() {
     local timezone=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${timezone}"; then
         channel=$(bashio::var.json timezone "${timezone}")
@@ -195,7 +195,7 @@ function bashio::supervisor.timezone() {
 function bashio::supervisor.country() {
     local country=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${country}"; then
         channel=$(bashio::var.json country "${country}")
@@ -215,7 +215,7 @@ function bashio::supervisor.country() {
 function bashio::supervisor.logging() {
     local logging=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${logging}"; then
         logging=$(bashio::var.json logging "${logging}")
@@ -243,7 +243,7 @@ function bashio::supervisor.ip_address() {
 function bashio::supervisor.debug() {
     local debug=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${debug}"; then
         if bashio::var.true "${debug}"; then
@@ -267,7 +267,7 @@ function bashio::supervisor.debug() {
 function bashio::supervisor.debug_block() {
     local debug=${1:-}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${debug}"; then
         if bashio::var.true "${debug}"; then

--- a/lib/var.sh
+++ b/lib/var.sh
@@ -16,7 +16,7 @@
 function bashio::var.true() {
     local value=${1:-null}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ "${value}" = "true" ]]; then
         return "${__BASHIO_EXIT_OK}"
@@ -34,7 +34,7 @@ function bashio::var.true() {
 function bashio::var.false() {
     local value=${1:-null}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ "${value}" = "false" ]]; then
         return "${__BASHIO_EXIT_OK}"
@@ -52,7 +52,7 @@ function bashio::var.false() {
 bashio::var.defined() {
     local variable=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     [[ "${!variable-X}" = "${!variable-Y}" ]]
 }
@@ -66,7 +66,7 @@ bashio::var.defined() {
 function bashio::var.has_value() {
     local value=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -n "${value}" ]]; then
         return "${__BASHIO_EXIT_OK}"
@@ -84,7 +84,7 @@ function bashio::var.has_value() {
 function bashio::var.is_empty() {
     local value=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -z "${value}" ]]; then
         return "${__BASHIO_EXIT_OK}"
@@ -104,7 +104,7 @@ function bashio::var.equals() {
     local value=${1}
     local equals=${2}
 
-    bashio::log.trace "${FUNCNAME[0]}:" "$@"
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ "${value}" = "${equals}" ]]; then
         return "${__BASHIO_EXIT_OK}"


### PR DESCRIPTION
# Proposed Changes

Copilot review comment https://github.com/hassio-addons/bashio/pull/188#discussion_r3045315155 "Consider standardizing the trace format within the module for easier log scanning/grepping."

It's true, there is way more `"${FUNCNAME[0]}" "$@"` than `"${FUNCNAME[0]}:" "$@"`

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated trace logging format across library modules by removing trailing colons from function name prefixes in log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->