### PR TITLE
Add a Bats test suite with coverage reporting

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -50,6 +50,22 @@ The following tools run on every pull request and must pass:
 - [codespell][codespell]: checks for common misspellings.
 - [zizmor][zizmor]: security auditing of the GitHub Actions workflows.
 
+## Tests
+
+The test suite lives in the [`tests`](../tests) folder and uses
+[Bats][bats-core]. After installing Bats, run it from the repository root:
+
+```bash
+bats tests/
+```
+
+Each module has its own `tests/<module>.bats` file; `tests/test_helper.bash`
+loads the library so its functions are available to the tests. When you fix a
+bug or add a function, please add a test that covers it.
+
+In CI the suite runs under [bashcov][bashcov] and coverage is uploaded to
+[Codecov][codecov].
+
 ## Pull request process
 
 1. Search the repository for open or closed [pull requests][prs] that relate to
@@ -64,7 +80,10 @@ The following tools run on every pull request and must pass:
    issues before you push.
 5. A maintainer will review your pull request and merge it once it is ready.
 
+[bashcov]: https://github.com/infertux/bashcov
+[bats-core]: https://github.com/bats-core/bats-core
 [bug-report]: https://github.com/hassio-addons/bashio/issues/new?template=bug_report.yml
+[codecov]: https://codecov.io/gh/hassio-addons/bashio
 [coc]: CODE_OF_CONDUCT.md
 [codespell]: https://github.com/codespell-project/codespell
 [discussions]: https://github.com/hassio-addons/bashio/discussions

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -63,8 +63,8 @@ Each module has its own `tests/<module>.bats` file; `tests/test_helper.bash`
 loads the library so its functions are available to the tests. When you fix a
 bug or add a function, please add a test that covers it.
 
-In CI the suite runs under [bashcov][bashcov] and coverage is uploaded to
-[Codecov][codecov].
+In CI the suite runs under [bashcov][bashcov] and coverage is uploaded to both
+[Codecov][codecov] and GitHub's native code coverage.
 
 ## Pull request process
 

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+---
+# Coverage is still growing; keep the checks informational so they never block a
+# pull request while the suite is being expanded.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,3 +106,27 @@ jobs:
         run: zizmor .github/workflows/
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⤵️ Check out code from GitHub
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: 🏗 Set up bats
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # 4.0.0
+      - name: 🏗 Set up Ruby
+        uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
+        with:
+          ruby-version: "3.4"
+      - name: 🏗 Install coverage tooling
+        run: gem install --no-document bashcov simplecov-cobertura
+      - name: 🚀 Run tests with coverage
+        run: bashcov -- bats tests/
+      - name: 📤 Upload coverage to Codecov
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        with:
+          files: ./coverage/coverage.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,6 +110,10 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     steps:
       - name: ⤵️ Check out code from GitHub
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -130,3 +134,10 @@ jobs:
         with:
           files: ./coverage/coverage.xml
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: 📤 Upload coverage to GitHub
+        uses: actions/upload-code-coverage@abb5995db9e0199b0e2bb9dbd136fce4cb1ec4d3 # v1.3.0
+        with:
+          file: ./coverage/coverage.xml
+          language: Shell
+          label: code-coverage/bats
+          fail-on-error: false

--- a/.simplecov
+++ b/.simplecov
@@ -1,0 +1,9 @@
+# Coverage configuration used by bashcov when running the Bats test suite.
+require "stringio"
+require "simplecov-cobertura"
+
+SimpleCov.start do
+  command_name "bats"
+  add_filter %r{/tests/}
+  formatter SimpleCov::Formatter::CoberturaFormatter
+end

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![GitHub Actions][github-actions-shield]][github-actions]
 [![OpenSSF Scorecard][scorecard-shield]][scorecard]
+[![Coverage on codecov][codecov-shield]][codecov]
 ![Project Maintenance][maintenance-shield]
 [![GitHub Activity][commits-shield]][commits]
 
@@ -171,6 +172,8 @@ SOFTWARE.
 [base-alpine]: https://github.com/hassio-addons/addon-base
 [base-debian]: https://github.com/hassio-addons/addon-debian-base
 [base-ubuntu]: https://github.com/hassio-addons/addon-ubuntu-base
+[codecov-shield]: https://codecov.io/gh/hassio-addons/bashio/branch/main/graph/badge.svg
+[codecov]: https://codecov.io/gh/hassio-addons/bashio
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/bashio.svg
 [commits]: https://github.com/hassio-addons/bashio/commits/main
 [contributors]: https://github.com/hassio-addons/bashio/graphs/contributors

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/api.sh (the Supervisor API client).
+#
+# The network boundary is stubbed by shadowing `curl` with a Bash function, so
+# no real HTTP requests are made. The stub emits a canned response body followed
+# by an HTTP status code, mimicking the real call that uses
+# `curl --write-out '\n%{http_code}'`.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    MOCK_BODY='{}'
+    MOCK_STATUS='200'
+    curl() {
+        printf '%s\n%s' "${MOCK_BODY}" "${MOCK_STATUS}"
+    }
+}
+
+@test "api.supervisor returns the filtered data on a successful response" {
+    MOCK_BODY='{"result":"ok","data":{"hello":"world"}}'
+    MOCK_STATUS='200'
+    run bashio::api.supervisor GET /test false '.hello'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "world" ]
+}
+
+@test "api.supervisor returns the raw body when raw output is requested" {
+    MOCK_BODY='just-raw-text'
+    MOCK_STATUS='200'
+    run bashio::api.supervisor GET /test true
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "just-raw-text" ]
+}
+
+@test "api.supervisor fails on an authentication error (401)" {
+    MOCK_BODY='{"result":"error","message":"unauthorized"}'
+    MOCK_STATUS='401'
+    run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}
+
+@test "api.supervisor fails on a not-found error (404)" {
+    MOCK_BODY='{"result":"error","message":"missing"}'
+    MOCK_STATUS='404'
+    run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}
+
+@test "api.supervisor fails when the API reports an error result" {
+    MOCK_BODY='{"result":"error","message":"boom"}'
+    MOCK_STATUS='200'
+    run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}

--- a/tests/string.bats
+++ b/tests/string.bats
@@ -1,0 +1,48 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/string.sh
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+@test "bashio::string.lower lowercases a string" {
+    run bashio::string.lower "HeLLo World"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "hello world" ]
+}
+
+@test "bashio::string.upper uppercases a string" {
+    run bashio::string.upper "HeLLo World"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "HELLO WORLD" ]
+}
+
+@test "bashio::string.length returns the length of a string" {
+    run bashio::string.length "abcde"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "5" ]
+}
+
+@test "bashio::string.length of an empty string is zero" {
+    run bashio::string.length ""
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "0" ]
+}
+
+@test "bashio::string.replace replaces all occurrences of a substring" {
+    run bashio::string.replace "foobarfoo" "foo" "baz"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "bazbarbaz" ]
+}
+
+@test "bashio::string.substring returns the rest from a position" {
+    run bashio::string.substring "abcABC123" 6
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "123" ]
+}
+
+@test "bashio::string.substring returns a slice with a length" {
+    run bashio::string.substring "abcABC123" 3 3
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "ABC" ]
+}

--- a/tests/supervisor.bats
+++ b/tests/supervisor.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/supervisor.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::supervisor` fetcher, jq filtering, and caching run. The cache is
+# pointed at a per-test temporary directory so tests stay isolated.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+@test "supervisor.ping calls the ping endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::supervisor.ping
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /supervisor/ping" ]
+}
+
+@test "supervisor.version extracts the version from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"2024.1.0","arch":"amd64"}'
+    }
+    run bashio::supervisor.version
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2024.1.0" ]
+}
+
+@test "supervisor.arch extracts the architecture from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"2024.1.0","arch":"amd64"}'
+    }
+    run bashio::supervisor.arch
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "amd64" ]
+}
+
+@test "supervisor.channel sends the channel as a JSON options object" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::supervisor.channel "beta"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /supervisor/options {"channel":"beta"}' ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Test helper: loads the bashio library so its functions are available to tests.
+# ==============================================================================
+
+# Resolve the repository root based on this file's location.
+BASHIO_TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pwd)"
+
+# shellcheck source=/dev/null
+source "${BASHIO_TEST_ROOT}/lib/bashio.sh"
+
+# Bashio enables errexit, nounset and pipefail when sourced. Relax them again so
+# they do not interfere with the Bats test runner.
+set +o errexit +o nounset +o pipefail

--- a/tests/var.bats
+++ b/tests/var.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/var.sh
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+@test "bashio::var.true succeeds for 'true'" {
+    run bashio::var.true "true"
+    [ "${status}" -eq 0 ]
+}
+
+@test "bashio::var.true fails for any other value" {
+    run bashio::var.true "false"
+    [ "${status}" -ne 0 ]
+}
+
+@test "bashio::var.false succeeds for 'false'" {
+    run bashio::var.false "false"
+    [ "${status}" -eq 0 ]
+}
+
+@test "bashio::var.has_value succeeds for a non-empty value" {
+    run bashio::var.has_value "something"
+    [ "${status}" -eq 0 ]
+}
+
+@test "bashio::var.has_value fails for an empty value" {
+    run bashio::var.has_value ""
+    [ "${status}" -ne 0 ]
+}
+
+@test "bashio::var.is_empty succeeds for an empty value" {
+    run bashio::var.is_empty ""
+    [ "${status}" -eq 0 ]
+}
+
+@test "bashio::var.equals succeeds for equal values" {
+    run bashio::var.equals "abc" "abc"
+    [ "${status}" -eq 0 ]
+}
+
+@test "bashio::var.equals fails for different values" {
+    run bashio::var.equals "abc" "xyz"
+    [ "${status}" -ne 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

Adds an automated test suite for bashio, which previously had none.

**Test harness**

- `tests/` with `test_helper.bash` that sources the library (and relaxes
  errexit/nounset/pipefail so they do not interfere with the Bats runner).
- `string.bats` and `var.bats` cover the pure, dependency-free functions.
- `api.bats` tests `bashio::api.supervisor` by shadowing `curl` with a Bash
  function that returns canned responses, exercising the success, raw, 401, 404
  and error-result paths.
- `supervisor.bats` stubs the `bashio::api.supervisor` boundary and lets the
  real fetcher, jq filtering and caching run; the cache is isolated per test.

**CI and coverage**

- A `Test` job in `ci.yaml` installs Bats (`bats-core/bats-action`), runs the
  suite under `bashcov`, and uploads the Cobertura report to Codecov
  (`codecov/codecov-action`).
- Coverage configuration lives in `.simplecov`; the Codecov status is
  informational (`.github/codecov.yml`) so it does not block pull requests while
  coverage grows.
- Adds a coverage badge to `README.md` and documents running the tests in
  `CONTRIBUTING.md`.

Note: Codecov uploads require a `CODECOV_TOKEN` repository secret and the
repository to be enabled on Codecov. CI does not fail if the upload is skipped.

## Related Issues

_None._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Contributing guide updated with a dedicated testing section describing test layout, how to run tests locally, and coverage reporting; README includes a coverage badge.

* **Tests**
  * New comprehensive test suites added for API, string utilities, supervisor features, and variable helpers, plus a test helper for consistent test setup.

* **Chores**
  * CI updated to run tests and publish coverage reports (non-blocking status).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->