### PR TITLE
Expand the Bats test suite

### DIFF
--- a/tests/config.bats
+++ b/tests/config.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/config.sh.
+#
+# `bashio::config` reads the add-on options through `bashio::addon.config`
+# (which normally calls the Supervisor API). That boundary is stubbed here with
+# a fixed options document, so the real jq-based parsing logic is exercised.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    bashio::addon.config() {
+        printf '%s' '{
+            "username": "frenck",
+            "port": 1234,
+            "ssl": true,
+            "debug": false,
+            "blank": ""
+        }'
+    }
+}
+
+@test "config returns a string value" {
+    run bashio::config "username"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "frenck" ]
+}
+
+@test "config returns the default for a missing key" {
+    run bashio::config "missing" "fallback"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "fallback" ]
+}
+
+@test "config.exists succeeds for a present key" {
+    run bashio::config.exists "username"
+    [ "${status}" -eq 0 ]
+}
+
+@test "config.exists fails for a missing key" {
+    run bashio::config.exists "missing"
+    [ "${status}" -ne 0 ]
+}
+
+@test "config.has_value fails for an empty value" {
+    run bashio::config.has_value "blank"
+    [ "${status}" -ne 0 ]
+}
+
+@test "config.true succeeds for a true option" {
+    run bashio::config.true "ssl"
+    [ "${status}" -eq 0 ]
+}
+
+@test "config.false succeeds for a false option" {
+    run bashio::config.false "debug"
+    [ "${status}" -eq 0 ]
+}
+
+@test "config.equals matches a numeric value" {
+    run bashio::config.equals "port" "1234"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/fs.bats
+++ b/tests/fs.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/fs.sh (filesystem helpers).
+#
+# These use the per-test temporary directory provided by Bats, so they touch
+# only throwaway paths.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+@test "fs.directory_exists succeeds for an existing directory" {
+    run bashio::fs.directory_exists "${BATS_TEST_TMPDIR}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "fs.directory_exists fails for a missing directory" {
+    run bashio::fs.directory_exists "${BATS_TEST_TMPDIR}/does-not-exist"
+    [ "${status}" -ne 0 ]
+}
+
+@test "fs.file_exists succeeds for an existing file" {
+    touch "${BATS_TEST_TMPDIR}/file"
+    run bashio::fs.file_exists "${BATS_TEST_TMPDIR}/file"
+    [ "${status}" -eq 0 ]
+}
+
+@test "fs.file_exists fails for a missing file" {
+    run bashio::fs.file_exists "${BATS_TEST_TMPDIR}/missing"
+    [ "${status}" -ne 0 ]
+}
+
+@test "fs.file_non_empty fails for an empty file" {
+    touch "${BATS_TEST_TMPDIR}/empty"
+    run bashio::fs.file_non_empty "${BATS_TEST_TMPDIR}/empty"
+    [ "${status}" -ne 0 ]
+}
+
+@test "fs.file_non_empty succeeds for a non-empty file" {
+    printf 'data' >"${BATS_TEST_TMPDIR}/full"
+    run bashio::fs.file_non_empty "${BATS_TEST_TMPDIR}/full"
+    [ "${status}" -eq 0 ]
+}
+
+@test "fs.device_exists succeeds for a character device" {
+    run bashio::fs.device_exists "/dev/null"
+    [ "${status}" -eq 0 ]
+}
+
+@test "fs.device_exists fails for a regular file" {
+    touch "${BATS_TEST_TMPDIR}/regular"
+    run bashio::fs.device_exists "${BATS_TEST_TMPDIR}/regular"
+    [ "${status}" -ne 0 ]
+}
+
+@test "fs.socket_exists fails for a regular file" {
+    touch "${BATS_TEST_TMPDIR}/not-a-socket"
+    run bashio::fs.socket_exists "${BATS_TEST_TMPDIR}/not-a-socket"
+    [ "${status}" -ne 0 ]
+}

--- a/tests/jq.bats
+++ b/tests/jq.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/jq.sh (JSON query helpers).
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+@test "jq applies a filter to a JSON string" {
+    run bashio::jq '{"name":"bashio","count":3}' '.name'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "bashio" ]
+}
+
+@test "jq.exists succeeds when the filtered value exists" {
+    run bashio::jq.exists '{"name":"bashio"}' '.name'
+    [ "${status}" -eq 0 ]
+}
+
+@test "jq.exists fails when the filtered value is null" {
+    run bashio::jq.exists '{"name":"bashio"}' '.missing'
+    [ "${status}" -ne 0 ]
+}
+
+@test "jq.is_string detects a string" {
+    run bashio::jq.is_string '{"name":"bashio"}' '.name'
+    [ "${status}" -eq 0 ]
+}
+
+@test "jq.is_number detects a number" {
+    run bashio::jq.is_number '{"count":3}' '.count'
+    [ "${status}" -eq 0 ]
+}
+
+@test "jq.is_string is false for a number" {
+    run bashio::jq.is_string '{"count":3}' '.count'
+    [ "${status}" -ne 0 ]
+}
+
+@test "jq.has_value succeeds for a non-empty result" {
+    run bashio::jq.has_value '{"items":[1,2]}' '.items'
+    [ "${status}" -eq 0 ]
+}
+
+@test "jq.has_value fails for an empty array" {
+    run bashio::jq.has_value '{"items":[]}' '.items'
+    [ "${status}" -ne 0 ]
+}

--- a/tests/supervisor.bats
+++ b/tests/supervisor.bats
@@ -44,3 +44,24 @@ setup() {
     [ "${status}" -eq 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /supervisor/options {"channel":"beta"}' ]
 }
+
+@test "supervisor.restart calls the restart endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::supervisor.restart
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /supervisor/restart" ]
+}
+
+@test "supervisor.logs_latest fetches the latest logs" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::supervisor.logs_latest
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /supervisor/logs/latest true" ]
+}
+
+@test "supervisor.diagnostics enables diagnostics as JSON options" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::supervisor.diagnostics "true"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /supervisor/options {"diagnostics":true}' ]
+}

--- a/tests/var.bats
+++ b/tests/var.bats
@@ -44,3 +44,26 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     run bashio::var.equals "abc" "xyz"
     [ "${status}" -ne 0 ]
 }
+
+@test "bashio::var.json builds a JSON object from key/value pairs" {
+    run bashio::var.json key "value"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"key":"value"}' ]
+}
+
+@test "bashio::var.json treats a ^-prefixed value as raw JSON" {
+    run bashio::var.json count "^42"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"count":42}' ]
+}
+
+@test "bashio::var.json fails for an odd number of arguments" {
+    run bashio::var.json only-a-key
+    [ "${status}" -ne 0 ]
+}
+
+@test "bashio::var.json_string escapes a string for JSON" {
+    run bashio::var.json_string 'he said "hi"'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '"he said \"hi\""' ]
+}


### PR DESCRIPTION
# Proposed Changes

Expands the Bats test suite added in #215, growing the test count from 24 to 56
and covering more of the library.

- `tests/fs.bats`: filesystem helpers (`directory_exists`, `file_exists`,
  `file_non_empty`, `device_exists`, `socket_exists`), using the per-test
  temporary directory.
- `tests/config.bats`: the config getters, stubbing `bashio::addon.config` with
  a fixed options document so the real jq-based parsing is exercised.
- `tests/jq.bats`: the JSON query helpers (`jq`, `jq.exists`, `jq.is_*`,
  `jq.has_value`) with explicit filters.
- `tests/var.bats`: adds the `var.json` and `var.json_string` cases.
- `tests/supervisor.bats`: adds the functions introduced in #205 (`restart`,
  `logs_latest`, `diagnostics`).

These reuse the existing patterns: pure functions are called directly, while the
API/config boundaries are stubbed.

## Related Issues

_None._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for configuration management, filesystem operations, JSON processing, supervisor integration, and variable utilities to enhance reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->