### PR TITLE
Fix supervisor.timezone and supervisor.country setters

### DIFF
--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -204,7 +204,7 @@ function bashio::supervisor.timezone() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${timezone}"; then
-        channel=$(bashio::var.json timezone "${timezone}")
+        timezone=$(bashio::var.json timezone "${timezone}")
         bashio::api.supervisor POST /supervisor/options "${timezone}"
         bashio::cache.flush_all
     else
@@ -224,7 +224,7 @@ function bashio::supervisor.country() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${country}"; then
-        channel=$(bashio::var.json country "${country}")
+        country=$(bashio::var.json country "${country}")
         bashio::api.supervisor POST /supervisor/options "${country}"
         bashio::cache.flush_all
     else

--- a/tests/supervisor.bats
+++ b/tests/supervisor.bats
@@ -65,3 +65,17 @@ setup() {
     [ "${status}" -eq 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /supervisor/options {"diagnostics":true}' ]
 }
+
+@test "supervisor.timezone sets the timezone as JSON options" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::supervisor.timezone "Europe/Amsterdam"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /supervisor/options {"timezone":"Europe/Amsterdam"}' ]
+}
+
+@test "supervisor.country sets the country as JSON options" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::supervisor.country "NL"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /supervisor/options {"country":"NL"}' ]
+}

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -10,6 +10,7 @@ BASHIO_TEST_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." >/dev/null 2>&1 && pw
 # shellcheck source=/dev/null
 source "${BASHIO_TEST_ROOT}/lib/bashio.sh"
 
-# Bashio enables errexit, nounset and pipefail when sourced. Relax them again so
-# they do not interfere with the Bats test runner.
-set +o errexit +o nounset +o pipefail
+# Bashio enables errexit, nounset and pipefail when sourced. Bats relies on
+# errexit to detect failing commands, so it must stay enabled. Bats' own `run`
+# helper is not nounset-safe, so relax only nounset.
+set +o nounset


### PR DESCRIPTION
# Proposed Changes

**Bug fix (Supervisor setters)**

`bashio::supervisor.timezone` and `bashio::supervisor.country` built the JSON
request body into a stray `channel` variable but then POSTed the raw argument.
As a result the Supervisor received e.g. `Europe/Amsterdam` instead of
`{"timezone":"Europe/Amsterdam"}`, so setting the timezone or country did not
work. Both now assign to the correct variable and POST the JSON, matching
`bashio::supervisor.channel`.

**Test harness fix**

While adding regression tests, I found the Bats helper disabled `errexit`. Bats
relies on `errexit` to detect failing commands, so failing assertions were
silently passing and the suite was not actually enforcing anything. The helper
now keeps `errexit` enabled and relaxes only `nounset` (which Bats' `run` helper
is not safe under). With this fix the new tests correctly fail against the old
code and pass against the fix.

**Tests**

- `tests/supervisor.bats`: regression tests asserting that `timezone` and
  `country` POST the correct JSON options body.

## Related Issues

_None._
