### PR TITLE
Fix jq helpers when the optional filter is omitted

### DIFF
--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -16,7 +16,7 @@
 # ------------------------------------------------------------------------------
 function bashio::jq() {
     local data=${1}
-    local filter=${2:-}
+    local filter=${2:-.}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
@@ -36,7 +36,7 @@ function bashio::jq() {
 # ------------------------------------------------------------------------------
 function bashio::jq.exists() {
     local data=${1}
-    local filter=${2:-}
+    local filter=${2:-.}
     local value
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
@@ -58,7 +58,7 @@ function bashio::jq.exists() {
 # ------------------------------------------------------------------------------
 function bashio::jq.has_value() {
     local data=${1}
-    local filter=${2:-}
+    local filter=${2:-.}
     local value
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
@@ -82,7 +82,7 @@ function bashio::jq.has_value() {
 # ------------------------------------------------------------------------------
 function bashio::jq.is() {
     local data=${1}
-    local filter=${2}
+    local filter=${2:-.}
     local type=${3}
     local value
 

--- a/tests/jq.bats
+++ b/tests/jq.bats
@@ -45,3 +45,27 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     run bashio::jq.has_value '{"items":[]}' '.items'
     [ "${status}" -ne 0 ]
 }
+
+# The filter argument is documented as optional; without it the helpers should
+# operate on the whole document (identity filter).
+
+@test "jq without a filter returns the whole document" {
+    run bashio::jq '{"a":1}'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"a":1}' ]
+}
+
+@test "jq.exists without a filter succeeds for non-empty data" {
+    run bashio::jq.exists '{"a":1}'
+    [ "${status}" -eq 0 ]
+}
+
+@test "jq.has_value without a filter succeeds for a non-empty object" {
+    run bashio::jq.has_value '{"a":1}'
+    [ "${status}" -eq 0 ]
+}
+
+@test "jq.is_object without a filter detects an object" {
+    run bashio::jq.is_object '{"a":1}'
+    [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

The `$2` filter argument of `bashio::jq`, `bashio::jq.exists`,
`bashio::jq.has_value` and the `bashio::jq.is_*` family is documented as
optional, but omitting it made jq error out ("Top-level program not given", or a
syntax error from the composed `| ...` filter). As a result those helpers always
returned a failure or `false` when used without a filter.

The filter now defaults to the identity filter (`.`), so without a filter the
helpers operate on the whole document as documented.

**Tests**

- `tests/jq.bats`: regression tests covering the no-filter behaviour of `jq`,
  `jq.exists`, `jq.has_value` and `jq.is_object`.

## Related Issues

_None._
