### PR TITLE
Fix config options leak, editorconfig typo, and bug-report label

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,14 +6,17 @@ end_of_line = lf
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
-ident_size = 4
+indent_size = 4
 
 [*.md]
-ident_size = 2
+indent_size = 2
 trim_trailing_whitespace = false
 
 [*.json]
-ident_size = 2
+indent_size = 2
+
+[*.{yaml,yml}]
+indent_size = 2
 
 [{.gitignore,.gitkeep,.editorconfig}]
-ident_size = 2
+indent_size = 2

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,7 +3,7 @@
 name: Bug Report
 description: Report a problem with one of Bashio's functions or modules.
 labels:
-  - bug
+  - bugfix
 body:
   - type: markdown
     attributes:

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -19,6 +19,7 @@ function bashio::config() {
     local default_value=${2:-null}
     local query
     local result
+    local options
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 

--- a/tests/config.bats
+++ b/tests/config.bats
@@ -62,3 +62,11 @@ setup() {
     run bashio::config.equals "port" "1234"
     [ "${status}" -eq 0 ]
 }
+
+@test "config does not leak its options variable into the caller's scope" {
+    # A caller may legitimately use a variable named 'options'; bashio::config
+    # must not clobber it.
+    options="caller-value"
+    bashio::config "username" >/dev/null
+    [ "${options}" = "caller-value" ]
+}


### PR DESCRIPTION
# Proposed Changes

Three small fixes found during the code review.

**`bashio::config` leaked an `options` global**

`bashio::config` declared `key`, `default_value`, `query` and `result` as local
but not `options`, so calling it clobbered any variable named `options` in the
caller's scope. It is now declared local, with a regression test in
`tests/config.bats`.

**`.editorconfig` used a misspelled key**

Every block used `ident_size` instead of `indent_size`, so EditorConfig (and
Prettier, which reads it) silently ignored the intended indent sizes. Renamed to
`indent_size`. Because the `[*]` block sets `indent_size = 4` (correct for the
shell scripts), a `[*.{yaml,yml}]` override of `2` was added so YAML keeps the
2-space indentation that yamllint enforces.

**Bug report form used a non-existent label**

The bug report issue form applied a `bug` label, which is not part of
`labels.yml` (only `bugfix` is). Changed to `bugfix`.

## Related Issues

_None._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated editor configuration settings for consistent indentation across file types
  * Updated bug report issue template default label

* **Tests**
  * Added test to verify proper variable scope isolation in configuration functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->