### PR TITLE
Make bashio::string.replace replace the needle literally

### DIFF
--- a/lib/string.sh
+++ b/lib/string.sh
@@ -50,7 +50,7 @@ function bashio::string.replace() {
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
-    printf "%s" "${string//${needle}/${replacement}}"
+    printf "%s" "${string//"${needle}"/${replacement}}"
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/string.bats
+++ b/tests/string.bats
@@ -46,3 +46,15 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     [ "${status}" -eq 0 ]
     [ "${output}" = "ABC" ]
 }
+
+@test "bashio::string.replace treats an asterisk needle literally" {
+    run bashio::string.replace "a*b*c" "*" "-"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "a-b-c" ]
+}
+
+@test "bashio::string.replace treats a question-mark needle literally" {
+    run bashio::string.replace "a?b" "?" "-"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "a-b" ]
+}


### PR DESCRIPTION
# Proposed Changes

`bashio::string.replace` used the needle unquoted inside
`${string//${needle}/${replacement}}`, so Bash treated it as a glob pattern.
Needles containing `*`, `?` or `[` were not matched literally (for example,
replacing `*` replaced the entire string). The needle is now quoted so it is
matched literally, matching the documented behaviour ("String part to replace").

This is technically a behaviour change for any caller that relied on the
(undocumented) glob matching.

**Tests**

- `tests/string.bats`: regression tests for literal `*` and `?` needles.

## Related Issues

_None._
