### PR TITLE
Source the observer module in bashio.sh

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -86,6 +86,8 @@ source "${__BASHIO_LIB_DIR}/multicast.sh"
 source "${__BASHIO_LIB_DIR}/net.sh"
 # shellcheck source=lib/network.sh
 source "${__BASHIO_LIB_DIR}/network.sh"
+# shellcheck source=lib/observer.sh
+source "${__BASHIO_LIB_DIR}/observer.sh"
 # shellcheck source=lib/os.sh
 source "${__BASHIO_LIB_DIR}/os.sh"
 # shellcheck source=lib/pwned.sh

--- a/tests/observer.bats
+++ b/tests/observer.bats
@@ -1,0 +1,23 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/observer.sh.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+@test "observer module is loaded by bashio" {
+    run type -t bashio::observer.update
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "function" ]
+}
+
+@test "observer.update propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::observer.update || rc=$?
+    [ "${rc}" -ne 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

`lib/observer.sh` was present but never sourced by `lib/bashio.sh`, so every
`bashio::observer.*` function (update, version, host, stats, cpu_percent, ...)
was unavailable to apps using bashio. Add the missing
`source "${__BASHIO_LIB_DIR}/observer.sh"` (alphabetically, between `network.sh`
and `os.sh`).

This was found while expanding the setter tests in #221.

**Tests**

- `tests/observer.bats`: asserts the observer module is loaded, and that
  `observer.update` propagates an API failure.

## Related Issues

_None._
