### PR TITLE
Do not log the full password hash in bashio::pwned

### DIFF
--- a/lib/pwned.sh
+++ b/lib/pwned.sh
@@ -88,7 +88,6 @@ function bashio::pwned() {
             tr '[:lower:]' '[:upper:]' |
             awk -F' ' '{ print $1 }'
     )
-    bashio::log.debug "Password SHA1: ${password}"
 
     # Check with have I Been Pwned, only send the first 5 chars of the hash
     if ! response=$(

--- a/tests/pwned.bats
+++ b/tests/pwned.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/pwned.sh.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+@test "pwned does not log the full password hash, even at debug level" {
+    # Stub Have I Been Pwned: respond 200 with no matching suffix.
+    curl() { printf '\n200'; }
+
+    # Enable debug logging and capture it to a file.
+    __BASHIO_LOG_LEVEL="${__BASHIO_LOG_LEVEL_DEBUG}"
+    exec {LOG_FD}>"${BATS_TEST_TMPDIR}/log"
+
+    bashio::pwned "test" >/dev/null
+
+    run cat "${BATS_TEST_TMPDIR}/log"
+    # The full SHA-1 of "test" must never appear in the logs (only the 5-char
+    # k-anonymity prefix is sent to, and logged for, the API).
+    [[ "${output}" != *"A94A8FE5CCB19BA61C4C0873D391E987982FBBD3"* ]]
+}


### PR DESCRIPTION
# Proposed Changes

`bashio::pwned` logged the full SHA-1 of the user's password at debug level
(`Password SHA1: <hash>`). App logs are routinely shared publicly, so this
exposed the complete hash, enabling offline cracking of weak passwords.

The line is removed. Nothing is lost for debugging: the 5-char k-anonymity
prefix that is actually sent to the Have I Been Pwned API is still logged on the
following line.

**Tests**

- `tests/pwned.bats`: with debug logging enabled and captured, asserts the full
  password SHA-1 never appears in the output.

## Related Issues

_None._
