### PR TITLE
Stop logging the plaintext password in bashio::pwned

### DIFF
--- a/lib/pwned.sh
+++ b/lib/pwned.sh
@@ -73,10 +73,10 @@ function bashio::pwned() {
     local hibp_hash
     local count
 
-    bashio::log.trace "${FUNCNAME[0]}" "${password//./x}"
+    bashio::log.trace "${FUNCNAME[0]}" "<REDACTED PASSWORD>"
 
     # Do not check empty password
-    if ! bashio::var.has_value "${password}"; then
+    if [[ -z "${password}" ]]; then
         bashio::log.warning 'Cannot check empty password against HaveIBeenPwned.'
         return "${__BASHIO_EXIT_NOK}"
     fi

--- a/tests/pwned.bats
+++ b/tests/pwned.bats
@@ -1,22 +1,35 @@
 #!/usr/bin/env bats
 # ==============================================================================
 # Tests for lib/pwned.sh.
+#
+# The logging functions are stubbed to record everything passed to them, so the
+# tests assert directly that no secret is ever handed to a log call (independent
+# of the configured log level or format).
 # ==============================================================================
 
 source "${BATS_TEST_DIRNAME}/test_helper.bash"
 
-@test "pwned does not log the full password hash, even at debug level" {
-    # Stub Have I Been Pwned: respond 200 with no matching suffix.
+setup() {
+    BASHIO_TEST_LOG="${BATS_TEST_TMPDIR}/log"
+    : >"${BASHIO_TEST_LOG}"
+    bashio::log.trace() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.debug() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.info() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.warning() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.error() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+}
+
+@test "pwned never logs the full password hash" {
     curl() { printf '\n200'; }
-
-    # Enable debug logging and capture it to a file.
-    __BASHIO_LOG_LEVEL="${__BASHIO_LOG_LEVEL_DEBUG}"
-    exec {LOG_FD}>"${BATS_TEST_TMPDIR}/log"
-
     bashio::pwned "test" >/dev/null
-
-    run cat "${BATS_TEST_TMPDIR}/log"
-    # The full SHA-1 of "test" must never appear in the logs (only the 5-char
-    # k-anonymity prefix is sent to, and logged for, the API).
+    run cat "${BASHIO_TEST_LOG}"
+    # Only the 5-char k-anonymity prefix may be logged, never the full SHA-1.
     [[ "${output}" != *"A94A8FE5CCB19BA61C4C0873D391E987982FBBD3"* ]]
+}
+
+@test "pwned never logs the plaintext password" {
+    curl() { printf '\n200'; }
+    bashio::pwned "SuperSecretValue" >/dev/null
+    run cat "${BASHIO_TEST_LOG}"
+    [[ "${output}" != *"SuperSecretValue"* ]]
 }


### PR DESCRIPTION
# Proposed Changes

`bashio::pwned` could log the user's plaintext password at trace level via two
paths:

1. A weak mask: `bashio::log.trace ... "${password//./x}"` only replaced dots, so
   a password without dots was logged verbatim.
2. `bashio::var.has_value "${password}"` passed the raw password as an argument,
   and that function traces its arguments.

Both are fixed: the trace now uses the `<REDACTED PASSWORD>` placeholder already
used by the sibling functions, and the empty check is done inline with
`[[ -z ... ]]` so the password is never passed to a tracing function.

`tests/pwned.bats` is rewritten to stub the logging functions and assert
directly that no secret is ever passed to a log call. This is robust to the log
level/format: the previous `LOG_FD`-capture approach rendered empty under Bats,
which made the test added in #223 vacuous. It now genuinely verifies that
neither the full hash nor the plaintext password is logged.

## Related Issues

_None._
