### PR TITLE
Documentation and configuration hygiene

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -43,7 +43,6 @@ version-resolver:
   patch:
     labels:
       - "bugfix"
-      - "chore"
       - "ci"
       - "dependencies"
       - "documentation"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ name: CI
 # yamllint disable-line rule:truthy
 on:
   push:
+    branches:
+      - main
   pull_request:
     types:
       - opened

--- a/lib/config.sh
+++ b/lib/config.sh
@@ -379,7 +379,7 @@ function bashio::config.require.username() {
 #   $1 Key of the config option (optional: defaults to 'username')
 # ------------------------------------------------------------------------------
 function bashio::config.suggest.username() {
-    local key=${1}
+    local key=${1:-"username"}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -202,7 +202,7 @@ function bashio::core.boot() {
 # ------------------------------------------------------------------------------
 function bashio::core.port() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::core 'core.port' '.port'
+    bashio::core 'core.info.port' '.port'
 }
 
 # ------------------------------------------------------------------------------

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -86,7 +86,10 @@ function bashio::host() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns the hostname of the host system.
+# Returns or sets the hostname of the host system.
+#
+# Arguments:
+#   $1 Hostname to set (optional).
 # ------------------------------------------------------------------------------
 function bashio::host.hostname() {
     local hostname=${1:-}
@@ -167,7 +170,7 @@ function bashio::host.disk_total() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns the available diskspace on the host.
+# Returns the used diskspace on the host.
 # ------------------------------------------------------------------------------
 function bashio::host.disk_used() {
     bashio::log.trace "${FUNCNAME[0]}"

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -162,5 +162,5 @@ function bashio::info.operating_system() {
 # ------------------------------------------------------------------------------
 function bashio::info.state() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::info 'supervisor.info.running' '.state'
+    bashio::info 'supervisor.info.state' '.state'
 }

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -98,7 +98,7 @@ function bashio::os.version_latest() {
 }
 
 # ------------------------------------------------------------------------------
-# Checks if there is an update available for the Supervisor.
+# Checks if there is an update available for the OS.
 # ------------------------------------------------------------------------------
 function bashio::os.update_available() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"


### PR DESCRIPTION
# Proposed Changes

A batch of low-risk documentation and configuration cleanups from the code
review.

**Documentation**

- `bashio::host.disk_used` docstring said "available" (copy-pasted from
  `disk_free`); it returns _used_ disk space.
- `bashio::os.update_available` docstring said "Supervisor"; it checks the OS.
- `bashio::host.hostname` now documents its optional set argument.

**Behaviour / consistency**

- Cache keys now match the data they hold: `bashio::info.state` used
  `supervisor.info.running` (now `supervisor.info.state`) and `bashio::core.port`
  used `core.port` (now `core.info.port`, matching the `core.info.*` convention).
- `bashio::config.suggest.username` defaults its key to `"username"`, matching
  `bashio::config.require.username`.

**Repository config**

- Release Drafter no longer references a non-existent `chore` label in its patch
  version resolver.
- `ci.yaml`'s `push` trigger is restricted to `main`, so pull request branches no
  longer run the whole CI matrix twice (once for `push`, once for
  `pull_request`).

## Related Issues

_None._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow configuration to restrict pipeline runs to the main branch
  * Modified release version-resolution rules to refine versioning behavior

* **Bug Fixes**
  * Fixed configuration handling with proper default parameter assignment
  * Corrected function calls for retrieving system information and state data
  * Updated internal cache key resolution for consistency

* **Documentation**
  * Enhanced function documentation with expanded parameter descriptions
  * Improved inline comments for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hassio-addons/bashio/pull/225?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->