### PR TITLE
Pass the Supervisor token to curl via stdin, not argv

### DIFF
--- a/lib/api.sh
+++ b/lib/api.sh
@@ -40,15 +40,16 @@ function bashio::api.supervisor() {
     fi
 
     if ! response=$(
-        # Pass the authorization header via stdin (curl --config) instead of a
+        # Pass the authorization header via stdin (curl -H @-) instead of a
         # command-line argument, so the Supervisor token is not exposed in the
-        # process list (/proc/<pid>/cmdline).
+        # process list (/proc/<pid>/cmdline). Reading the header from stdin keeps
+        # the value literal, so tokens with special characters are handled safely.
         curl --silent --show-error \
             --write-out '\n%{http_code}' --request "${method}" \
+            -H @- \
             -H "Content-Type: application/json" \
             -d "${data}" \
-            --config - \
-            "${__BASHIO_SUPERVISOR_API}${resource}" <<<"header = \"${auth_header}\""
+            "${__BASHIO_SUPERVISOR_API}${resource}" <<<"${auth_header}"
     ); then
         bashio::log.debug "${response}"
         bashio::log.error "Something went wrong contacting the API"

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -40,12 +40,15 @@ function bashio::api.supervisor() {
     fi
 
     if ! response=$(
+        # Pass the authorization header via stdin (curl --config) instead of a
+        # command-line argument, so the Supervisor token is not exposed in the
+        # process list (/proc/<pid>/cmdline).
         curl --silent --show-error \
             --write-out '\n%{http_code}' --request "${method}" \
-            -H "${auth_header}" \
             -H "Content-Type: application/json" \
             -d "${data}" \
-            "${__BASHIO_SUPERVISOR_API}${resource}"
+            --config - \
+            "${__BASHIO_SUPERVISOR_API}${resource}" <<<"header = \"${auth_header}\""
     ); then
         bashio::log.debug "${response}"
         bashio::log.error "Something went wrong contacting the API"

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -54,3 +54,20 @@ setup() {
     run bashio::api.supervisor GET /test
     [ "${status}" -ne 0 ]
 }
+
+@test "api.supervisor keeps the auth token out of the curl arguments" {
+    __BASHIO_SUPERVISOR_TOKEN="SUPER_SECRET_TOKEN"
+    # Record curl's arguments and its stdin (the --config input) separately.
+    curl() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/argv"
+        cat >"${BATS_TEST_TMPDIR}/stdin"
+        printf '%s\n%s' '{"result":"ok"}' '200'
+    }
+    bashio::api.supervisor GET /test true >/dev/null
+    # The token must not appear in the process arguments...
+    run cat "${BATS_TEST_TMPDIR}/argv"
+    [[ "${output}" != *"SUPER_SECRET_TOKEN"* ]]
+    # ...but must be supplied via stdin (the curl config).
+    run cat "${BATS_TEST_TMPDIR}/stdin"
+    [[ "${output}" == *"SUPER_SECRET_TOKEN"* ]]
+}

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -57,7 +57,7 @@ setup() {
 
 @test "api.supervisor keeps the auth token out of the curl arguments" {
     __BASHIO_SUPERVISOR_TOKEN="SUPER_SECRET_TOKEN"
-    # Record curl's arguments and its stdin (the --config input) separately.
+    # Record curl's arguments and its stdin (the -H @- header) separately.
     curl() {
         printf '%s' "$*" >"${BATS_TEST_TMPDIR}/argv"
         cat >"${BATS_TEST_TMPDIR}/stdin"
@@ -67,7 +67,7 @@ setup() {
     # The token must not appear in the process arguments...
     run cat "${BATS_TEST_TMPDIR}/argv"
     [[ "${output}" != *"SUPER_SECRET_TOKEN"* ]]
-    # ...but must be supplied via stdin (the curl config).
+    # ...but must be supplied via stdin (the -H @- header).
     run cat "${BATS_TEST_TMPDIR}/stdin"
     [[ "${output}" == *"SUPER_SECRET_TOKEN"* ]]
 }


### PR DESCRIPTION
# Proposed Changes

`bashio::api.supervisor` passed the `Authorization: Bearer <token>` header as a
`curl -H` command-line argument. Process arguments are visible via
`/proc/<pid>/cmdline` to any other process in the container, so the Supervisor
token (which grants full Supervisor API access) was exposed to any additional
processes an app runs.

The header is now read from stdin via `curl -H @-`, so the token never appears
in the process arguments, and its value is handled literally (so tokens with
special characters are safe).

**Tests**

- `tests/api.bats`: stubs curl to record its arguments and stdin separately and
  asserts the token is passed via stdin (the `-H @-` header), never in the argv.

## Related Issues

_None._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented authentication tokens from appearing in system process arguments during API requests, enhancing credential security.

* **Tests**
  * Added automated test coverage to verify tokens are not exposed in command-line arguments and are transmitted securely via standard input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->