### PR TITLE
Prevent JSON injection in add-on option values

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -602,21 +602,24 @@ function bashio::addon.option() {
     local value=${2:-}
     local slug=${3:-'self'}
     local options
-    local item
+    local value_argument
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
     options=$(bashio::addon.options "${slug}")
 
     if bashio::var.has_value "${value}"; then
-        item="\"$value\""
+        # Pass the value through a jq variable so it cannot break out of the
+        # JSON to inject additional keys. A "^" prefix marks a raw JSON value
+        # (number, boolean, object); anything else is treated as a string.
+        value_argument=(--arg value "${value}")
         if [[ "${value:0:1}" == "^" ]]; then
-            item="${value:1}"
+            value_argument=(--argjson value "${value:1}")
         fi
 
         if bashio::jq.exists "${options}" ".${key}"; then
-            options=$(bashio::jq "${options}" ".${key} |= ${item}")
+            options=$(bashio::jq "${options}" ".${key} |= \$value" "${value_argument[@]}")
         else
-            options=$(bashio::jq "${options}" ".${key} = ${item}")
+            options=$(bashio::jq "${options}" ".${key} = \$value" "${value_argument[@]}")
         fi
     else
         options=$(bashio::jq "${options}" "del(.${key})")

--- a/lib/jq.sh
+++ b/lib/jq.sh
@@ -13,17 +13,19 @@
 # Arguments:
 #   $1 JSON string or path to a JSON file
 #   $2 jq filter (optional)
+#   $@ Extra jq arguments, e.g. --arg/--argjson to pass values safely (optional)
 # ------------------------------------------------------------------------------
 function bashio::jq() {
     local data=${1}
     local filter=${2:-.}
+    local arguments=("${@:3}")
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if [[ -f "${data}" ]]; then
-        jq --raw-output -c -M "$filter" "${data}"
+        jq --raw-output -c -M "${arguments[@]}" "$filter" "${data}"
     else
-        jq --raw-output -c -M "$filter" <<<"${data}"
+        jq --raw-output -c -M "${arguments[@]}" "$filter" <<<"${data}"
     fi
 }
 

--- a/tests/addons.bats
+++ b/tests/addons.bats
@@ -22,3 +22,32 @@ setup() {
     bashio::addon.update "example" || rc=$?
     [ "${rc}" -ne 0 ]
 }
+
+@test "addon.option stores the value as a literal string (no JSON injection)" {
+    bashio::addon.options() {
+        if [[ $# -le 1 ]]; then
+            printf '%s' '{"existing":"x"}'
+        else
+            printf '%s' "$2" >"${BATS_TEST_TMPDIR}/opts"
+        fi
+    }
+    bashio::addon.option "name" 'a","injected":"b'
+    # The crafted value is stored verbatim as a string...
+    [ "$(jq -r '.name' <"${BATS_TEST_TMPDIR}/opts")" = 'a","injected":"b' ]
+    # ...and must not have injected a separate key.
+    run jq -e 'has("injected")' <"${BATS_TEST_TMPDIR}/opts"
+    [ "${status}" -ne 0 ]
+}
+
+@test "addon.option sets a raw JSON value with the ^ prefix" {
+    bashio::addon.options() {
+        if [[ $# -le 1 ]]; then
+            printf '%s' '{}'
+        else
+            printf '%s' "$2" >"${BATS_TEST_TMPDIR}/opts"
+        fi
+    }
+    bashio::addon.option "enabled" "^true"
+    run jq -e '.enabled == true' <"${BATS_TEST_TMPDIR}/opts"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/jq.bats
+++ b/tests/jq.bats
@@ -69,3 +69,9 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     run bashio::jq.is_object '{"a":1}'
     [ "${status}" -eq 0 ]
 }
+
+@test "jq forwards extra arguments (--arg) and binds the value literally" {
+    run bashio::jq '{}' '.name = $value' --arg value 'a"b'
+    [ "${status}" -eq 0 ]
+    [ "$(jq -r '.name' <<<"${output}")" = 'a"b' ]
+}


### PR DESCRIPTION
# Proposed Changes

`bashio::addon.option` built its jq program by concatenating the option
value straight into the filter (`item="\"$value\""`). A value containing
a double quote could break out of the JSON string and inject arbitrary
keys into the options object, for example:

```bash
bashio::addon.option "name" 'a","injected":"b'
```

would write `"name": "a", "injected": "b"` instead of storing the value
verbatim.

The value is now bound to a jq `$value` variable via `--arg` (or
`--argjson` for the existing `^` raw-JSON prefix), so it is always
treated as data and can never alter the program. To support this,
`bashio::jq` now forwards any extra arguments to `jq`, letting callers
pass `--arg`/`--argjson` safely.

Scope note: jq filters and option keys remain author-controlled jq
expressions by design (so nested key paths keep working); only the
externally supplied value is hardened.

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `bashio::jq` now accepts additional jq CLI arguments for extended functionality.

* **Bug Fixes**
  * Improved addon option value handling to prevent injection vulnerabilities.

* **Tests**
  * Added test coverage for addon option handling and jq argument forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->