### PR TITLE
Keep the Supervisor request body off argv and out of the logs

### DIFF
--- a/lib/api.sh
+++ b/lib/api.sh
@@ -57,7 +57,13 @@ function bashio::api.supervisor() {
             bashio::log.error "Could not create a temporary file for the API request"
             return "${__BASHIO_EXIT_NOK}"
         fi
-        printf '%s' "${data}" >"${data_file}"
+        # Remove the file (which may hold a secret) if the body cannot be
+        # written, rather than sending a partial body or leaking it on disk.
+        if ! printf '%s' "${data}" >"${data_file}"; then
+            rm -f "${data_file}"
+            bashio::log.error "Could not write the API request body to disk"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         data_args=(--data-binary @"${data_file}")
     else
         data_args=(--data-binary "${data}")

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -26,7 +26,7 @@ function bashio::api.supervisor() {
     local response
     local status
     local data='{}'
-    local data_file
+    local data_file=''
     local result
 
     # The request body can carry secrets (for example app options), so it is
@@ -45,15 +45,23 @@ function bashio::api.supervisor() {
         raw=
     fi
 
-    # Pass the request body through a temporary file (curl --data-binary @file)
-    # instead of a command-line argument, so a body carrying secrets is not
-    # exposed in the process list (/proc/<pid>/cmdline). The file is created
-    # with restrictive permissions by mktemp and removed right after the call.
-    if ! data_file=$(mktemp); then
-        bashio::log.error "Could not create a temporary file for the API request"
-        return "${__BASHIO_EXIT_NOK}"
+    # Only a POST body can carry secrets, so just that case is routed through a
+    # temporary file (curl --data-binary @file) instead of a command-line
+    # argument, keeping it out of the process list (/proc/<pid>/cmdline). The
+    # file is created with restrictive permissions by mktemp and removed right
+    # after the call. Other methods send their constant, non-sensitive body
+    # inline and therefore do not depend on mktemp.
+    local data_args
+    if [[ "${method}" = "POST" ]]; then
+        if ! data_file=$(mktemp); then
+            bashio::log.error "Could not create a temporary file for the API request"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        printf '%s' "${data}" >"${data_file}"
+        data_args=(--data-binary @"${data_file}")
+    else
+        data_args=(--data-binary "${data}")
     fi
-    printf '%s' "${data}" >"${data_file}"
 
     if ! response=$(
         # Pass the authorization header via stdin (curl -H @-) instead of a
@@ -64,15 +72,15 @@ function bashio::api.supervisor() {
             --write-out '\n%{http_code}' --request "${method}" \
             -H @- \
             -H "Content-Type: application/json" \
-            --data-binary @"${data_file}" \
+            "${data_args[@]}" \
             "${__BASHIO_SUPERVISOR_API}${resource}" <<<"${auth_header}"
     ); then
-        rm -f "${data_file}"
+        [[ -n "${data_file}" ]] && rm -f "${data_file}"
         bashio::log.debug "${response}"
         bashio::log.error "Something went wrong contacting the API"
         return "${__BASHIO_EXIT_NOK}"
     fi
-    rm -f "${data_file}"
+    [[ -n "${data_file}" ]] && rm -f "${data_file}"
 
     status=${response##*$'\n'}
     response=${response%"$status"}

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -26,18 +26,31 @@ function bashio::api.supervisor() {
     local response
     local status
     local data='{}'
+    local data_file
     local result
 
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    # The request body can carry secrets (for example app options), so it is
+    # deliberately kept out of the trace log.
+    bashio::log.trace "${FUNCNAME[0]}" "${method}" "${resource}"
 
     if [[ -n "${__BASHIO_SUPERVISOR_TOKEN:-}" ]]; then
         auth_header="Authorization: Bearer ${__BASHIO_SUPERVISOR_TOKEN}"
     fi
 
-    if [[ "${method}" = "POST" ]] && bashio::var.has_value "${raw}"; then
+    # Use a plain emptiness test (not bashio::var.has_value) so the request
+    # body, which can carry secrets, is never passed to a helper that traces
+    # its arguments.
+    if [[ "${method}" = "POST" ]] && [[ -n "${raw}" ]]; then
         data="${raw}"
         raw=
     fi
+
+    # Pass the request body through a temporary file (curl --data-binary @file)
+    # instead of a command-line argument, so a body carrying secrets is not
+    # exposed in the process list (/proc/<pid>/cmdline). The file is created
+    # with restrictive permissions by mktemp and removed right after the call.
+    data_file=$(mktemp)
+    printf '%s' "${data}" >"${data_file}"
 
     if ! response=$(
         # Pass the authorization header via stdin (curl -H @-) instead of a
@@ -48,20 +61,21 @@ function bashio::api.supervisor() {
             --write-out '\n%{http_code}' --request "${method}" \
             -H @- \
             -H "Content-Type: application/json" \
-            -d "${data}" \
+            --data-binary @"${data_file}" \
             "${__BASHIO_SUPERVISOR_API}${resource}" <<<"${auth_header}"
     ); then
+        rm -f "${data_file}"
         bashio::log.debug "${response}"
         bashio::log.error "Something went wrong contacting the API"
         return "${__BASHIO_EXIT_NOK}"
     fi
+    rm -f "${data_file}"
 
     status=${response##*$'\n'}
     response=${response%"$status"}
 
     bashio::log.debug "Requested API resource: ${__BASHIO_SUPERVISOR_API}${resource}"
     bashio::log.debug "Request method: ${method}"
-    bashio::log.debug "Request data: ${data}"
     bashio::log.debug "API HTTP Response code: ${status}"
     bashio::log.debug "API Response: ${response}"
 

--- a/lib/api.sh
+++ b/lib/api.sh
@@ -49,7 +49,10 @@ function bashio::api.supervisor() {
     # instead of a command-line argument, so a body carrying secrets is not
     # exposed in the process list (/proc/<pid>/cmdline). The file is created
     # with restrictive permissions by mktemp and removed right after the call.
-    data_file=$(mktemp)
+    if ! data_file=$(mktemp); then
+        bashio::log.error "Could not create a temporary file for the API request"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
     printf '%s' "${data}" >"${data_file}"
 
     if ! response=$(

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -118,6 +118,26 @@ setup() {
     [ "${curl_called}" -eq 0 ]
 }
 
+@test "api.supervisor cleans up and fails if the body cannot be written" {
+    # Point mktemp at an unwritable path so the body write fails.
+    mktemp() { printf '%s' "/nonexistent-dir/bashio-body"; }
+    msg=''
+    bashio::log.error() { msg="$*"; }
+    curl_called=0
+    curl() {
+        curl_called=1
+        printf '%s\n%s' '{"result":"ok"}' '200'
+    }
+    rc=0
+    bashio::api.supervisor POST /test '{"password":"x"}' >/dev/null || rc=$?
+    # It must report the failure without sending the request...
+    [ "${rc}" -ne 0 ]
+    [ -n "${msg}" ]
+    [ "${curl_called}" -eq 0 ]
+    # ...and must not leave the body file behind.
+    [ ! -e "/nonexistent-dir/bashio-body" ]
+}
+
 @test "api.supervisor GET does not depend on mktemp" {
     # A GET has no secret body, so it must not fail when mktemp is unavailable.
     mktemp() { return 1; }

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -119,8 +119,10 @@ setup() {
 }
 
 @test "api.supervisor cleans up and fails if the body cannot be written" {
-    # Point mktemp at an unwritable path so the body write fails.
-    mktemp() { printf '%s' "/nonexistent-dir/bashio-body"; }
+    # Point mktemp at a path whose parent directories do not exist (and are not
+    # created), so the body write deterministically fails.
+    local target="${BATS_TEST_TMPDIR}/missing/subdir/bashio-body"
+    mktemp() { printf '%s' "${target}"; }
     msg=''
     bashio::log.error() { msg="$*"; }
     curl_called=0
@@ -135,7 +137,7 @@ setup() {
     [ -n "${msg}" ]
     [ "${curl_called}" -eq 0 ]
     # ...and must not leave the body file behind.
-    [ ! -e "/nonexistent-dir/bashio-body" ]
+    [ ! -e "${target}" ]
 }
 
 @test "api.supervisor GET does not depend on mktemp" {

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -71,3 +71,39 @@ setup() {
     run cat "${BATS_TEST_TMPDIR}/stdin"
     [[ "${output}" == *"SUPER_SECRET_TOKEN"* ]]
 }
+
+@test "api.supervisor keeps the POST body out of the curl arguments" {
+    # Record argv, and resolve the --data-binary @file reference to its content.
+    curl() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/argv"
+        local prev='' arg body=''
+        for arg in "$@"; do
+            if [[ "${prev}" == "--data-binary" || "${prev}" == "--data" || "${prev}" == "-d" ]]; then
+                body="${arg}"
+            fi
+            prev="${arg}"
+        done
+        if [[ "${body}" == @* ]]; then
+            cat "${body:1}" >"${BATS_TEST_TMPDIR}/body"
+        else
+            printf '%s' "${body}" >"${BATS_TEST_TMPDIR}/body"
+        fi
+        cat >/dev/null
+        printf '%s\n%s' '{"result":"ok"}' '200'
+    }
+    bashio::api.supervisor POST /test '{"password":"SUPER_SECRET_BODY"}' >/dev/null
+    # The body must not appear in the process arguments...
+    run cat "${BATS_TEST_TMPDIR}/argv"
+    [[ "${output}" != *"SUPER_SECRET_BODY"* ]]
+    # ...but must still be delivered to curl (via the data file).
+    run cat "${BATS_TEST_TMPDIR}/body"
+    [[ "${output}" == *"SUPER_SECRET_BODY"* ]]
+}
+
+@test "api.supervisor never logs the request body" {
+    log_out=''
+    bashio::log.debug() { log_out+=" $*"; }
+    bashio::log.trace() { log_out+=" $*"; }
+    bashio::api.supervisor POST /test '{"password":"SECRET_IN_BODY"}' >/dev/null
+    [[ "${log_out}" != *"SECRET_IN_BODY"* ]]
+}

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -118,6 +118,15 @@ setup() {
     [ "${curl_called}" -eq 0 ]
 }
 
+@test "api.supervisor GET does not depend on mktemp" {
+    # A GET has no secret body, so it must not fail when mktemp is unavailable.
+    mktemp() { return 1; }
+    MOCK_BODY='{"result":"ok","data":{"hello":"world"}}'
+    run bashio::api.supervisor GET /test false '.hello'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "world" ]
+}
+
 @test "api.supervisor never logs the request body" {
     log_out=''
     bashio::log.debug() { log_out+=" $*"; }

--- a/tests/api.bats
+++ b/tests/api.bats
@@ -100,6 +100,24 @@ setup() {
     [[ "${output}" == *"SUPER_SECRET_BODY"* ]]
 }
 
+@test "api.supervisor fails cleanly when the temp file cannot be created" {
+    mktemp() { return 1; }
+    msg=''
+    bashio::log.error() { msg="$*"; }
+    curl_called=0
+    curl() {
+        curl_called=1
+        printf '%s\n%s' '{"result":"ok"}' '200'
+    }
+    rc=0
+    bashio::api.supervisor POST /test '{}' >/dev/null || rc=$?
+    # It must report the failure...
+    [ "${rc}" -ne 0 ]
+    [ -n "${msg}" ]
+    # ...without ever reaching the network call.
+    [ "${curl_called}" -eq 0 ]
+}
+
 @test "api.supervisor never logs the request body" {
     log_out=''
     bashio::log.debug() { log_out+=" $*"; }


### PR DESCRIPTION
# Proposed Changes

A Supervisor POST request body can carry secrets (for example app options being written back), but it was exposed in two ways:

- It was passed to `curl` via `-d "${data}"` on the command line, making it readable in `/proc/<pid>/cmdline` by other processes in the container.
- It was written verbatim to the logs: at trace level (the raw argument list, and again through the `bashio::var.has_value` helper that traces its arguments) and at debug level (the `Request data:` line).

This change:

- Passes the body through a temporary file (`curl --data-binary @file`,  created with restrictive permissions by `mktemp` and removed right after the call) so it no longer appears on the command line.
- Stops the trace log from receiving the raw arguments, and replaces the `bashio::var.has_value "${raw}"` body check with a plain `[[ -n ... ]]` test so the body is never routed through a tracing helper.
- Drops the `Request data:` debug line.

This mirrors the earlier fix (#226) that moved the authorization token off `argv` and onto stdin.

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * POST requests no longer expose sensitive request bodies in logs or command-line invocation.
  * Improved error handling when temporary file creation or writes fail, preventing unsafe behavior and surfacing errors for POST flows.
  * GET requests unaffected by POST-specific file handling.

* **Tests**
  * New tests verify request-body secrecy, logging safety, and correct behavior on temporary-file failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->