### PR TITLE
Harden the cache directory permissions and JSON key escaping

### DIFF
--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -71,6 +71,11 @@ function bashio::cache.set() {
     chmod 0700 "${__BASHIO_CACHE_DIR}" ||
         bashio::exit.nok "Could not restrict permissions on the cache folder"
 
+    # Remove any existing entry first, so the value is always written to a
+    # freshly created file instead of inheriting a permissive mode from a file
+    # left behind by an older version.
+    rm -f "${__BASHIO_CACHE_DIR}/${key}.cache"
+
     # Write under a tight umask so the cache file (which can hold secrets) is
     # created owner-only instead of with the ambient umask.
     if ! (umask 077 && printf "%s" "$value" >"${__BASHIO_CACHE_DIR}/${key}.cache"); then

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -58,7 +58,10 @@ function bashio::cache.set() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if ! bashio::fs.directory_exists "${__BASHIO_CACHE_DIR}"; then
-        mkdir -p "${__BASHIO_CACHE_DIR}" ||
+        # Cached values can contain secrets, so create the directory with an
+        # owner-only umask instead of relying on the (predictable) default
+        # permissions. A subshell keeps the umask change local to this call.
+        (umask 077 && mkdir -p "${__BASHIO_CACHE_DIR}") ||
             bashio::exit.nok "Could not create cache folder"
     fi
 

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -65,6 +65,12 @@ function bashio::cache.set() {
             bashio::exit.nok "Could not create cache folder"
     fi
 
+    # Enforce owner-only access even if the directory already existed, for
+    # example one left behind by an older version with broader permissions.
+    if ! chmod 0700 "${__BASHIO_CACHE_DIR}"; then
+        bashio::log.warning "Could not restrict permissions on the cache folder"
+    fi
+
     if ! printf "%s" "$value" >"${__BASHIO_CACHE_DIR}/${key}.cache"; then
         bashio::log.warning "An error occurred while storing ${key} to cache"
         return "${__BASHIO_EXIT_NOK}"

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -61,20 +61,24 @@ function bashio::cache.set() {
         # Cached values can contain secrets, so create the directory with an
         # owner-only umask instead of relying on the (predictable) default
         # permissions. A subshell keeps the umask change local to this call.
-        (umask 077 && mkdir -p "${__BASHIO_CACHE_DIR}") ||
+        (umask 077 && mkdir -p -- "${__BASHIO_CACHE_DIR}") ||
             bashio::exit.nok "Could not create cache folder"
     fi
 
     # Enforce owner-only access even if the directory already existed, for
     # example one left behind by an older version with broader permissions.
     # Fail hard rather than write secrets into a directory we cannot secure.
-    chmod 0700 "${__BASHIO_CACHE_DIR}" ||
+    chmod 0700 -- "${__BASHIO_CACHE_DIR}" ||
         bashio::exit.nok "Could not restrict permissions on the cache folder"
 
     # Remove any existing entry first, so the value is always written to a
-    # freshly created file instead of inheriting a permissive mode from a file
-    # left behind by an older version.
-    rm -f "${__BASHIO_CACHE_DIR}/${key}.cache"
+    # freshly created file instead of inheriting a permissive mode (or
+    # following a symlink) from a file left behind by an older version. If the
+    # removal fails, abort rather than write into an unknown target.
+    if ! rm -f -- "${__BASHIO_CACHE_DIR}/${key}.cache"; then
+        bashio::log.warning "An error occurred while storing ${key} to cache"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
 
     # Write under a tight umask so the cache file (which can hold secrets) is
     # created owner-only instead of with the ambient umask.

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -67,11 +67,13 @@ function bashio::cache.set() {
 
     # Enforce owner-only access even if the directory already existed, for
     # example one left behind by an older version with broader permissions.
-    if ! chmod 0700 "${__BASHIO_CACHE_DIR}"; then
-        bashio::log.warning "Could not restrict permissions on the cache folder"
-    fi
+    # Fail hard rather than write secrets into a directory we cannot secure.
+    chmod 0700 "${__BASHIO_CACHE_DIR}" ||
+        bashio::exit.nok "Could not restrict permissions on the cache folder"
 
-    if ! printf "%s" "$value" >"${__BASHIO_CACHE_DIR}/${key}.cache"; then
+    # Write under a tight umask so the cache file (which can hold secrets) is
+    # created owner-only instead of with the ambient umask.
+    if ! (umask 077 && printf "%s" "$value" >"${__BASHIO_CACHE_DIR}/${key}.cache"); then
         bashio::log.warning "An error occurred while storing ${key} to cache"
         return "${__BASHIO_EXIT_NOK}"
     fi

--- a/lib/var.sh
+++ b/lib/var.sh
@@ -139,8 +139,6 @@ function bashio::var.json() {
 
     counter=0
     for i in "${data[@]}"; do
-        item="\"$i\""
-
         separator=","
         if [ $((++counter % 2)) -eq 0 ]; then
             separator=":"
@@ -150,6 +148,10 @@ function bashio::var.json() {
             else
                 item=$(bashio::var.json_string "${i}")
             fi
+        else
+            # Object keys are always JSON strings and must be escaped, so a key
+            # containing a quote or backslash cannot break out of the JSON.
+            item=$(bashio::var.json_string "${i}")
         fi
 
         json="$json$separator$item"

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -29,13 +29,17 @@ setup() {
     bashio::cache.set "key" "value"
     [ -d "${__BASHIO_CACHE_DIR}" ]
     [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}")" = "700" ]
+    # The cache file itself must also be owner-only.
+    [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}/key.cache")" = "600" ]
 }
 
 @test "cache.set tightens permissions on an existing cache directory" {
     # A directory left behind by an older version (or another process) with
     # broader permissions must be restricted before secrets are written into it.
+    umask 022
     mkdir -p "${__BASHIO_CACHE_DIR}"
     chmod 0755 "${__BASHIO_CACHE_DIR}"
     bashio::cache.set "key" "value"
     [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}")" = "700" ]
+    [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}/key.cache")" = "600" ]
 }

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -44,6 +44,15 @@ setup() {
     [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}/key.cache")" = "600" ]
 }
 
+@test "cache.set fails if a stale entry cannot be removed" {
+    # If the existing entry cannot be removed, the value must not be written
+    # into an unknown target (for example a leftover symlink).
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    rm() { return 1; }
+    run bashio::cache.set "key" "value"
+    [ "${status}" -ne 0 ]
+}
+
 @test "cache.set tightens permissions on an existing cache file" {
     # A cache file left behind with a permissive mode must not keep that mode
     # when a new value is written into it.

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -46,9 +46,10 @@ setup() {
 
 @test "cache.set fails if a stale entry cannot be removed" {
     # If the existing entry cannot be removed, the value must not be written
-    # into an unknown target (for example a leftover symlink).
-    mkdir -p "${__BASHIO_CACHE_DIR}"
-    rm() { return 1; }
+    # into an unknown target (for example a leftover symlink). A directory in
+    # place of the cache file makes "rm -f" fail without stubbing rm (which
+    # bats itself relies on for cleanup).
+    mkdir -p "${__BASHIO_CACHE_DIR}/key.cache"
     run bashio::cache.set "key" "value"
     [ "${status}" -ne 0 ]
 }

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -23,8 +23,19 @@ setup() {
 
 @test "cache.set creates the cache directory with owner-only permissions" {
     # The cache can hold secrets, so the directory must not be accessible to
-    # other users in the container.
+    # other users in the container. Force a permissive umask first, so the test
+    # proves the result does not depend on the ambient umask.
+    umask 022
     bashio::cache.set "key" "value"
     [ -d "${__BASHIO_CACHE_DIR}" ]
+    [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}")" = "700" ]
+}
+
+@test "cache.set tightens permissions on an existing cache directory" {
+    # A directory left behind by an older version (or another process) with
+    # broader permissions must be restricted before secrets are written into it.
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    chmod 0755 "${__BASHIO_CACHE_DIR}"
+    bashio::cache.set "key" "value"
     [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}")" = "700" ]
 }

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/cache.sh (the on-disk key/value cache).
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+@test "cache.set then cache.get round-trips a value" {
+    bashio::cache.set "key" "value"
+    run bashio::cache.get "key"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "value" ]
+}
+
+@test "cache.get fails for an unknown key" {
+    run bashio::cache.get "missing"
+    [ "${status}" -ne 0 ]
+}
+
+@test "cache.set creates the cache directory with owner-only permissions" {
+    # The cache can hold secrets, so the directory must not be accessible to
+    # other users in the container.
+    bashio::cache.set "key" "value"
+    [ -d "${__BASHIO_CACHE_DIR}" ]
+    [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}")" = "700" ]
+}

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -43,3 +43,16 @@ setup() {
     [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}")" = "700" ]
     [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}/key.cache")" = "600" ]
 }
+
+@test "cache.set tightens permissions on an existing cache file" {
+    # A cache file left behind with a permissive mode must not keep that mode
+    # when a new value is written into it.
+    umask 022
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    : >"${__BASHIO_CACHE_DIR}/key.cache"
+    chmod 0644 "${__BASHIO_CACHE_DIR}/key.cache"
+    bashio::cache.set "key" "value"
+    [ "$(stat -c '%a' "${__BASHIO_CACHE_DIR}/key.cache")" = "600" ]
+    run bashio::cache.get "key"
+    [ "${output}" = "value" ]
+}

--- a/tests/var.bats
+++ b/tests/var.bats
@@ -67,6 +67,14 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     [ "$(jq -r 'to_entries[0].value' <<<"${output}")" = "value" ]
 }
 
+@test "bashio::var.json escapes a backslash in the key" {
+    run bashio::var.json 'a\b' "value"
+    [ "${status}" -eq 0 ]
+    [ "$(jq -r 'to_entries | length' <<<"${output}")" = "1" ]
+    [ "$(jq -r 'to_entries[0].key' <<<"${output}")" = 'a\b' ]
+    [ "$(jq -r 'to_entries[0].value' <<<"${output}")" = "value" ]
+}
+
 @test "bashio::var.json fails for an odd number of arguments" {
     run bashio::var.json only-a-key
     [ "${status}" -ne 0 ]

--- a/tests/var.bats
+++ b/tests/var.bats
@@ -57,6 +57,16 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     [ "${output}" = '{"count":42}' ]
 }
 
+@test "bashio::var.json escapes special characters in the key" {
+    run bashio::var.json 'a"b' "value"
+    [ "${status}" -eq 0 ]
+    # The output must be valid JSON whose single key is the literal input,
+    # with no structure injected by the embedded quote.
+    [ "$(jq -r 'to_entries | length' <<<"${output}")" = "1" ]
+    [ "$(jq -r 'to_entries[0].key' <<<"${output}")" = 'a"b' ]
+    [ "$(jq -r 'to_entries[0].value' <<<"${output}")" = "value" ]
+}
+
 @test "bashio::var.json fails for an odd number of arguments" {
     run bashio::var.json only-a-key
     [ "${status}" -ne 0 ]


### PR DESCRIPTION
# Proposed Changes

Two smaller hardening items from the security review (the remaining 9.5
sub-items).

**Cache directory permissions.** `bashio::cache.set` created the cache
directory (by default the predictable `/tmp/.bashio`) with `mkdir -p`,
which uses the default umask. Cached values can hold secrets (for
example API responses), so the directory and its contents were readable
by other users in the container. It is now created inside a `umask 077`
subshell, so the directory is owner-only and the umask change stays
local to the call.

**JSON object key escaping.** `bashio::var.json` escaped values via
`bashio::var.json_string` but wrapped keys in quotes verbatim
(`item="\"$i\""`). A key containing a `"` or backslash could therefore
break out of the JSON string and corrupt or inject structure. Keys are
now escaped the same way as values (they are always JSON strings, so the
`^` raw prefix does not apply to them).

Both changes add tests (`tests/var.bats`, new `tests/cache.bats`).

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced owner-only permissions for the on-disk cache, fail-fast on creation/permission errors, and ensure cache entries are written with owner-only permissions.
  * Improved JSON generation to reliably escape special characters in object keys (quotes, backslashes).
* **Tests**
  * Added tests for cache create/get behavior, permission tightening, handling of stale/unremovable entries, and rewriting overly permissive cache files.
  * Added tests verifying JSON key escaping for keys with quotes and backslashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->