### PR TITLE
Fix inaccurate docstrings across the library

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -895,7 +895,7 @@ function bashio::addon.usb() {
 # Returns whether or not this app has an icon available.
 #
 # Arguments:
-#   $1 App slug
+#   $1 App slug (optional, default: self)
 # ------------------------------------------------------------------------------
 function bashio::addon.icon() {
     local slug=${1:-'self'}

--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -54,7 +54,7 @@ function bashio::audio.logs() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns a JSON object with generic version information about audio the server.
+# Returns a JSON object with generic version information about the audio server.
 #
 # Arguments:
 #   $1 Cache key to store results in (optional)

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -38,7 +38,7 @@ function bashio::log.reinitialize_output() {
 # Log a message to output.
 #
 # Arguments:
-#   $1 Message to display
+#   $* Message to display
 # ------------------------------------------------------------------------------
 bashio::log() {
     local message=$*
@@ -50,7 +50,7 @@ bashio::log() {
 # Log a message to output (in red).
 #
 # Arguments:
-#   $1 Message to display
+#   $* Message to display
 # ------------------------------------------------------------------------------
 bashio::log.red() {
     local message=$*
@@ -62,7 +62,7 @@ bashio::log.red() {
 # Log a message to output (in green).
 #
 # Arguments:
-#   $1 Message to display
+#   $* Message to display
 # ------------------------------------------------------------------------------
 bashio::log.green() {
     local message=$*
@@ -74,7 +74,7 @@ bashio::log.green() {
 # Log a message to output (in yellow).
 #
 # Arguments:
-#   $1 Message to display
+#   $* Message to display
 # ------------------------------------------------------------------------------
 bashio::log.yellow() {
     local message=$*
@@ -86,7 +86,7 @@ bashio::log.yellow() {
 # Log a message to output (in blue).
 #
 # Arguments:
-#   $1 Message to display
+#   $* Message to display
 # ------------------------------------------------------------------------------
 bashio::log.blue() {
     local message=$*
@@ -98,7 +98,7 @@ bashio::log.blue() {
 # Log a message to output (in magenta).
 #
 # Arguments:
-#   $1 Message to display
+#   $* Message to display
 # ------------------------------------------------------------------------------
 bashio::log.magenta() {
     local message=$*
@@ -110,7 +110,7 @@ bashio::log.magenta() {
 # Log a message to output (in cyan).
 #
 # Arguments:
-#   $1 Message to display
+#   $* Message to display
 # ------------------------------------------------------------------------------
 bashio::log.cyan() {
     local message=$*

--- a/lib/string.sh
+++ b/lib/string.sh
@@ -74,7 +74,7 @@ bashio::string.length() {
 # bashio::string.substring "${stringZ}" 0      # abcABC123ABCabc
 # bashio::string.substring "${stringZ}" 1      # bcABC123ABCabc
 # bashio::string.substring "${stringZ}" 7      # 23ABCabc
-# bashio::string.substring "${stringZ}" 7 3    # 23AB
+# bashio::string.substring "${stringZ}" 7 3    # 23A
 #
 # Arguments:
 #   $1 String to return a substring of

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -233,7 +233,7 @@ function bashio::supervisor.country() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns the current logging level of the Supervisor.
+# Returns or sets the current logging level of the Supervisor.
 #
 # Arguments:
 #   $1 Logging level to set (optional).
@@ -261,7 +261,7 @@ function bashio::supervisor.ip_address() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns if debug is enabled on the supervisor
+# Returns or sets if debug is enabled on the Supervisor.
 #
 # Arguments:
 #   $1 Set debug (optional).
@@ -285,7 +285,7 @@ function bashio::supervisor.debug() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns if debug block is enabled on the supervisor
+# Returns or sets if debug block is enabled on the Supervisor.
 #
 # Arguments:
 #   $1 Set debug block (optional).


### PR DESCRIPTION
# Proposed Changes

A docstring-accuracy audit across `lib/*.sh` (every `bashio::` function's
comment block compared against its implementation). Coverage was already
effectively complete; this fixes the docstrings whose text contradicted
the code:

- `addon.icon`: `$1` slug is optional and defaults to `self`
  (`local slug=${1:-'self'}`), like every sibling getter; it was
  documented as required.
- `supervisor.logging` / `supervisor.debug` / `supervisor.debug_block`:
  these also POST to `/supervisor/options` when given a value, so the
  description now reads "Returns or sets ..." (matching the other
  setters), instead of "Returns ...".
- `bashio::log` and the colour helpers (`log.red`/`green`/`yellow`/
  `blue`/`magenta`/`cyan`): they read `local message=$*` (all arguments
  are joined), so the argument is documented as `$*`, matching the
  `log.trace`/`log.debug` family. It previously said `$1`.
- `string.substring`: the `"${stringZ}" 7 3` example returns `23A`
  (three characters from index 7), not `23AB`.
- `audio`: fix the garbled "about audio the server" wording.

Comment-only changes; no behaviour change.

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated argument descriptions and function behavior documentation across multiple modules for improved clarity and accuracy.
  * Corrected wording in function descriptions.
  * Improved documentation examples to reflect actual outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->