### PR TITLE
Add test coverage for lib/log.sh

### DIFF
--- a/tests/log.bats
+++ b/tests/log.bats
@@ -83,14 +83,35 @@ setup() {
     done
 }
 
-@test "log.level maps names to numeric levels case-insensitively" {
-    bashio::log.level "DEBUG"
-    [ "${__BASHIO_LOG_LEVEL}" -eq "${__BASHIO_LOG_LEVEL_DEBUG}" ]
+@test "log.level maps every level name to its numeric value" {
+    # Covers every arm of the case statement and guards against a name being
+    # wired to the wrong level. 'critical' is an alias for fatal.
+    declare -A expected=(
+        [all]="${__BASHIO_LOG_LEVEL_ALL}"
+        [trace]="${__BASHIO_LOG_LEVEL_TRACE}"
+        [debug]="${__BASHIO_LOG_LEVEL_DEBUG}"
+        [info]="${__BASHIO_LOG_LEVEL_INFO}"
+        [notice]="${__BASHIO_LOG_LEVEL_NOTICE}"
+        [warning]="${__BASHIO_LOG_LEVEL_WARNING}"
+        [error]="${__BASHIO_LOG_LEVEL_ERROR}"
+        [fatal]="${__BASHIO_LOG_LEVEL_FATAL}"
+        [critical]="${__BASHIO_LOG_LEVEL_FATAL}"
+        [off]="${__BASHIO_LOG_LEVEL_OFF}"
+    )
+    for name in "${!expected[@]}"; do
+        # Keep internal logging silent before each call: log.level resolves the
+        # name via `$(bashio::string.lower ...)`, and because this suite points
+        # LOG_FD at fd 1, a verbose level would let string.lower's own trace
+        # leak into that command substitution and corrupt the match.
+        __BASHIO_LOG_LEVEL="${__BASHIO_LOG_LEVEL_OFF}"
+        bashio::log.level "${name}"
+        [ "${__BASHIO_LOG_LEVEL}" -eq "${expected[$name]}" ]
+    done
 }
 
-@test "log.level accepts the 'critical' alias for fatal" {
-    bashio::log.level critical
-    [ "${__BASHIO_LOG_LEVEL}" -eq "${__BASHIO_LOG_LEVEL_FATAL}" ]
+@test "log.level matches level names case-insensitively" {
+    bashio::log.level "DEBUG"
+    [ "${__BASHIO_LOG_LEVEL}" -eq "${__BASHIO_LOG_LEVEL_DEBUG}" ]
 }
 
 @test "log.level off silences even fatal messages" {

--- a/tests/log.bats
+++ b/tests/log.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/log.sh.
+#
+# The log helpers write to the fd in $LOG_FD (a dup of the original STDOUT) so
+# that logging bypasses `$(...)` capture. For these tests we point $LOG_FD at
+# fd 1, so bats' `run` captures the emitted lines directly. The configured log
+# level is reset in setup() so the level-gating tests are deterministic.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    LOG_FD=1
+    # Set the runtime log globals explicitly. Bashio's `declare`d defaults do
+    # not survive the way bats re-sources the library, so the suite must not
+    # depend on them; pin them to the documented defaults instead.
+    __BASHIO_LOG_LEVEL=5 # INFO, the default
+    __BASHIO_LOG_FORMAT="[{TIMESTAMP}] {LEVEL}: {MESSAGE}"
+    __BASHIO_LOG_TIMESTAMP="%T"
+}
+
+@test "log joins all of its arguments into one line" {
+    run bashio::log one two three
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "one two three" ]
+}
+
+@test "the colour helpers wrap the message in their own colour code" {
+    run bashio::log.red x
+    [ "${output}" = "$(printf '%b' "${__BASHIO_COLORS_RED}x${__BASHIO_COLORS_RESET}")" ]
+    run bashio::log.green x
+    [ "${output}" = "$(printf '%b' "${__BASHIO_COLORS_GREEN}x${__BASHIO_COLORS_RESET}")" ]
+    run bashio::log.yellow x
+    [ "${output}" = "$(printf '%b' "${__BASHIO_COLORS_YELLOW}x${__BASHIO_COLORS_RESET}")" ]
+    run bashio::log.blue x
+    [ "${output}" = "$(printf '%b' "${__BASHIO_COLORS_BLUE}x${__BASHIO_COLORS_RESET}")" ]
+    run bashio::log.magenta x
+    [ "${output}" = "$(printf '%b' "${__BASHIO_COLORS_MAGENTA}x${__BASHIO_COLORS_RESET}")" ]
+    run bashio::log.cyan x
+    [ "${output}" = "$(printf '%b' "${__BASHIO_COLORS_CYAN}x${__BASHIO_COLORS_RESET}")" ]
+}
+
+@test "log.log substitutes every placeholder in the format" {
+    run bashio::log.log "${__BASHIO_LOG_LEVEL_INFO}" "hello"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"INFO: hello"* ]]
+    # No template placeholder may survive into the output.
+    [[ "${output}" != *"{TIMESTAMP}"* ]]
+    [[ "${output}" != *"{LEVEL}"* ]]
+    [[ "${output}" != *"{MESSAGE}"* ]]
+}
+
+@test "log.log suppresses a message above the configured level" {
+    run bashio::log.log "${__BASHIO_LOG_LEVEL_DEBUG}" "should not appear"
+    [ "${status}" -eq 0 ]
+    [ -z "${output}" ]
+}
+
+@test "log.info emits a green INFO line at the default level" {
+    run bashio::log.info "ready"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"INFO"* ]]
+    [[ "${output}" == *"ready"* ]]
+    [[ "${output}" == *"$(printf '%b' "${__BASHIO_COLORS_GREEN}")"* ]]
+}
+
+@test "log.debug and log.trace are silent at the default (INFO) level" {
+    run bashio::log.debug "debug message"
+    [ "${status}" -eq 0 ]
+    [ -z "${output}" ]
+    run bashio::log.trace "trace message"
+    [ "${status}" -eq 0 ]
+    [ -z "${output}" ]
+}
+
+@test "every level helper emits when the level is set to ALL" {
+    __BASHIO_LOG_LEVEL="${__BASHIO_LOG_LEVEL_ALL}"
+    for helper in trace debug info notice warning error fatal; do
+        run "bashio::log.${helper}" "msg-${helper}"
+        [ "${status}" -eq 0 ]
+        [[ "${output}" == *"msg-${helper}"* ]]
+    done
+}
+
+@test "log.level maps names to numeric levels case-insensitively" {
+    bashio::log.level "DEBUG"
+    [ "${__BASHIO_LOG_LEVEL}" -eq "${__BASHIO_LOG_LEVEL_DEBUG}" ]
+}
+
+@test "log.level accepts the 'critical' alias for fatal" {
+    bashio::log.level critical
+    [ "${__BASHIO_LOG_LEVEL}" -eq "${__BASHIO_LOG_LEVEL_FATAL}" ]
+}
+
+@test "log.level off silences even fatal messages" {
+    bashio::log.level off
+    [ "${__BASHIO_LOG_LEVEL}" -eq "${__BASHIO_LOG_LEVEL_OFF}" ]
+    run bashio::log.fatal "boom"
+    [ -z "${output}" ]
+}
+
+@test "log.level rejects an unknown level" {
+    run bashio::log.level "bogus"
+    [ "${status}" -ne 0 ]
+}
+
+@test "log.level takes effect on subsequent log calls" {
+    run bashio::log.debug "before"
+    [ -z "${output}" ]
+    bashio::log.level debug
+    run bashio::log.debug "after"
+    [ -n "${output}" ]
+    [[ "${output}" == *"after"* ]]
+}
+
+@test "log.reinitialize_output succeeds and logging keeps working" {
+    run bashio::log.reinitialize_output
+    [ "${status}" -eq 0 ]
+    run bashio::log "still logging"
+    [ "${output}" = "still logging" ]
+}


### PR DESCRIPTION
# Proposed Changes

First module in a per-module effort to raise test coverage with
meaningful tests (error paths, gating, boundaries), not happy-path only.

`lib/log.sh` had no tests; this adds `tests/log.bats` covering all 17
functions:

- `log` joins all arguments into one line.
- The six colour helpers each wrap the message in their own colour code
  (one test, guards against a copy-paste colour mix-up).
- `log.log` substitutes every `{TIMESTAMP}`/`{LEVEL}`/`{MESSAGE}`
  placeholder, and gates on the configured level in both directions
  (emits at/below the level, suppresses above it).
- The level-named helpers: `info` emits green at the default level,
  `debug`/`trace` are silent there, and every helper emits at `ALL`.
- `log.level`: case-insensitive name mapping, the `critical` alias for
  fatal, `off` silencing even fatal, an unknown level failing, and a
  level change taking effect on subsequent calls.

Tests point `LOG_FD` at fd 1 so bats captures the emitted lines, and pin
the runtime log globals in `setup()` (Bashio's `declare`d defaults do
not survive the way bats re-sources the library; production sources it
once at top level, so it is unaffected).

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive logging test suite validating deterministic output, level mapping (including aliases and case-insensitivity), helper-level emission and suppression, message templating/substitution, changing log levels at runtime, and reinitialization of logging output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->