### PR TITLE
Add test coverage for lib/exit.sh

### DIFF
--- a/tests/exit.bats
+++ b/tests/exit.bats
@@ -1,0 +1,91 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/exit.sh.
+#
+# These functions terminate the script with `exit`, so they are always invoked
+# through bats' `run` (which runs them in a subshell and captures the exit
+# status). LOG_FD is pointed at fd 1 and the log globals are pinned so the
+# fatal/warning messages they emit can be asserted on.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    LOG_FD=1
+    __BASHIO_LOG_LEVEL=5 # INFO: lets warning/fatal through, keeps trace quiet
+    __BASHIO_LOG_FORMAT="[{TIMESTAMP}] {LEVEL}: {MESSAGE}"
+    __BASHIO_LOG_TIMESTAMP="%T"
+}
+
+@test "exit.ok terminates with the success code" {
+    run bashio::exit.ok
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+}
+
+@test "exit.nok terminates with the failure code" {
+    run bashio::exit.nok
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+}
+
+@test "exit.nok logs the message at fatal level before exiting" {
+    run bashio::exit.nok "something broke"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"FATAL"* ]]
+    [[ "${output}" == *"something broke"* ]]
+}
+
+@test "die_if_false exits when the value is false" {
+    run bashio::exit.die_if_false "false"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+}
+
+@test "die_if_false continues when the value is true" {
+    run bashio::exit.die_if_false "true"
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+}
+
+@test "die_if_true exits when the value is true" {
+    run bashio::exit.die_if_true "true"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+}
+
+@test "die_if_true continues when the value is false" {
+    run bashio::exit.die_if_true "false"
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+}
+
+@test "die_if_empty exits when the value is empty" {
+    run bashio::exit.die_if_empty ""
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+}
+
+@test "die_if_empty continues when the value is non-empty" {
+    run bashio::exit.die_if_empty "present"
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+}
+
+@test "the die_if_* helpers forward their message to the fatal log" {
+    run bashio::exit.die_if_true "true" "boom from die_if_true"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"boom from die_if_true"* ]]
+}
+
+@test "the deprecated die_if_true alias warns and still delegates" {
+    # Triggering case: still exits with the failure code...
+    run hass.die_if_true "true" # codespell:ignore
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"deprecated"* ]]
+    # Non-triggering case: continues, but the deprecation warning is emitted.
+    run hass.die_if_true "false" # codespell:ignore
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+    [[ "${output}" == *"deprecated"* ]]
+}
+
+@test "the deprecated die_if_empty alias warns and still delegates" {
+    run hass.die_if_empty "" # codespell:ignore
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"deprecated"* ]]
+    run hass.die_if_empty "present" # codespell:ignore
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+    [[ "${output}" == *"deprecated"* ]]
+}

--- a/tests/exit.bats
+++ b/tests/exit.bats
@@ -25,6 +25,8 @@ setup() {
 @test "exit.nok terminates with the failure code" {
     run bashio::exit.nok
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    # Without a message it must not emit a fatal line.
+    [ -z "${output}" ]
 }
 
 @test "exit.nok logs the message at fatal level before exiting" {
@@ -65,9 +67,17 @@ setup() {
 }
 
 @test "the die_if_* helpers forward their message to the fatal log" {
+    run bashio::exit.die_if_false "false" "boom from die_if_false"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"boom from die_if_false"* ]]
+
     run bashio::exit.die_if_true "true" "boom from die_if_true"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
     [[ "${output}" == *"boom from die_if_true"* ]]
+
+    run bashio::exit.die_if_empty "" "boom from die_if_empty"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"boom from die_if_empty"* ]]
 }
 
 @test "the deprecated die_if_true alias warns and still delegates" {


### PR DESCRIPTION
# Proposed Changes

Per-module coverage, continuing with `lib/exit.sh` (previously untested).
Adds `tests/exit.bats` covering all seven functions, both directions:

- `exit.ok` / `exit.nok` exit with the success / failure code.
- `exit.nok` logs its message at fatal level before exiting (and emits
  nothing extra when called without a message).
- `die_if_false`, `die_if_true`, `die_if_empty` each exit on the
  triggering value and continue (return 0) otherwise.
- The `die_if_*` helpers forward their message to the fatal log.
- The deprecated `hass.die_if_true` / `hass.die_if_empty` aliases warn
  about deprecation and still delegate, in both the triggering and
  non-triggering cases.

The functions call `exit`, so they are invoked through `run`; `LOG_FD`
is pointed at fd 1 and the log globals pinned so the fatal/warning
output can be asserted. The deprecated-alias identifiers carry an inline
`# codespell:ignore`, matching how `lib/exit.sh` itself handles them.

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for exit codes and error handling behavior to enhance code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->