### PR TITLE
Add test coverage for lib/net.sh

### DIFF
--- a/tests/net.bats
+++ b/tests/net.bats
@@ -31,22 +31,31 @@ setup() {
     [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
 }
 
-@test "net.wait_for returns OK for an immediately available port" {
-    # Find a free port and open a listener with nc.
+@test "net.wait_for returns quickly when the port is already open" {
+    # Open a real listener so the fast path (port already reachable) is
+    # exercised, not just the return-code contract. A python3 listener is used
+    # because the nc invocation differs across implementations (busybox vs
+    # openbsd) and a single-shot listener would race with the connection; the
+    # backlog lets the connect succeed at the kernel level without accept().
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available to open a listener"
     local port=19876
-    # Start a simple listener that accepts one connection and exits.
-    nc -l -p "${port}" 127.0.0.1 >/dev/null 2>&1 &
-    local nc_pid=$!
+    python3 -c "import socket, time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('127.0.0.1', ${port}))
+s.listen(5)
+time.sleep(10)" &
+    local listener_pid=$!
     # Give the listener a moment to bind.
-    sleep 0.2
+    sleep 0.5
     local before after elapsed
     before="$(date +%s)"
     run bashio::net.wait_for "${port}" 127.0.0.1 5
     after="$(date +%s)"
     elapsed=$((after - before))
     # Clean up the listener regardless of test outcome.
-    kill "${nc_pid}" 2>/dev/null || true
-    wait "${nc_pid}" 2>/dev/null || true
+    kill "${listener_pid}" 2>/dev/null || true
+    wait "${listener_pid}" 2>/dev/null || true
     [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
     # The port was already open, so the call must return quickly (well under 2 s).
     [ "${elapsed}" -lt 2 ]

--- a/tests/net.bats
+++ b/tests/net.bats
@@ -39,24 +39,30 @@ setup() {
     local nc_pid=$!
     # Give the listener a moment to bind.
     sleep 0.2
+    local before after elapsed
+    before="$(date +%s)"
     run bashio::net.wait_for "${port}" 127.0.0.1 5
+    after="$(date +%s)"
+    elapsed=$((after - before))
     # Clean up the listener regardless of test outcome.
     kill "${nc_pid}" 2>/dev/null || true
     wait "${nc_pid}" 2>/dev/null || true
     [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+    # The port was already open, so the call must return quickly (well under 2 s).
+    [ "${elapsed}" -lt 2 ]
 }
 
 # ---------------------------------------------------------------------------
 # Default argument handling
 # ---------------------------------------------------------------------------
 
-@test "net.wait_for accepts only a port argument and uses localhost default" {
-    # Port 19998 unlikely to be open; timeout of 1 second; host defaults to localhost.
+@test "net.wait_for falls back to localhost when host argument is empty" {
+    # Port 19998 unlikely to be open; timeout of 1 second; empty host falls back to localhost.
     run bashio::net.wait_for 19998 "" 1
     [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
 }
 
-@test "net.wait_for with only a port argument does not hang beyond its timeout" {
+@test "net.wait_for does not hang beyond its explicit timeout when port is unreachable" {
     # The function internally defaults to 60-second timeout.
     # We supply an explicit short timeout to keep the suite fast.
     local before after elapsed

--- a/tests/net.bats
+++ b/tests/net.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/net.sh.
+#
+# bashio::net.wait_for blocks until a TCP port is reachable, then returns
+# __BASHIO_EXIT_OK. It always returns OK - failures are suppressed with
+# `|| true` and a timeout is used so it never hangs forever.
+#
+# To exercise the "port becomes available" path without relying on external
+# services we use netcat (nc) to open a listener on a random high port, then
+# call wait_for against it with a short timeout. The "port never opens" case
+# is exercised with a very short timeout against a port nothing is listening on.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    LOG_FD=1
+    __BASHIO_LOG_LEVEL="${__BASHIO_LOG_LEVEL_OFF}"  # keep trace output silent
+    __BASHIO_LOG_FORMAT="[{TIMESTAMP}] {LEVEL}: {MESSAGE}"
+    __BASHIO_LOG_TIMESTAMP="%T"
+}
+
+# ---------------------------------------------------------------------------
+# Return-code contract: always __BASHIO_EXIT_OK regardless of outcome
+# ---------------------------------------------------------------------------
+
+@test "net.wait_for returns OK even when the port never opens (timeout)" {
+    # Port 19999 is almost certainly not listening; timeout of 1 second.
+    run bashio::net.wait_for 19999 127.0.0.1 1
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+}
+
+@test "net.wait_for returns OK for an immediately available port" {
+    # Find a free port and open a listener with nc.
+    local port=19876
+    # Start a simple listener that accepts one connection and exits.
+    nc -l -p "${port}" 127.0.0.1 >/dev/null 2>&1 &
+    local nc_pid=$!
+    # Give the listener a moment to bind.
+    sleep 0.2
+    run bashio::net.wait_for "${port}" 127.0.0.1 5
+    # Clean up the listener regardless of test outcome.
+    kill "${nc_pid}" 2>/dev/null || true
+    wait "${nc_pid}" 2>/dev/null || true
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+}
+
+# ---------------------------------------------------------------------------
+# Default argument handling
+# ---------------------------------------------------------------------------
+
+@test "net.wait_for accepts only a port argument and uses localhost default" {
+    # Port 19998 unlikely to be open; timeout of 1 second; host defaults to localhost.
+    run bashio::net.wait_for 19998 "" 1
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+}
+
+@test "net.wait_for with only a port argument does not hang beyond its timeout" {
+    # The function internally defaults to 60-second timeout.
+    # We supply an explicit short timeout to keep the suite fast.
+    local before after elapsed
+    before="$(date +%s)"
+    run bashio::net.wait_for 19997 127.0.0.1 2
+    after="$(date +%s)"
+    elapsed=$(( after - before ))
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+    # Must finish well inside the 2-second window (allow 5 s for slow CI).
+    [ "${elapsed}" -lt 5 ]
+}
+
+# ---------------------------------------------------------------------------
+# Output contract: the function must not produce visible output
+# ---------------------------------------------------------------------------
+
+@test "net.wait_for emits no output on stdout when port is unreachable" {
+    run bashio::net.wait_for 19996 127.0.0.1 1
+    [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
+    [ -z "${output}" ]
+}

--- a/tests/net.bats
+++ b/tests/net.bats
@@ -16,7 +16,7 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
 
 setup() {
     LOG_FD=1
-    __BASHIO_LOG_LEVEL="${__BASHIO_LOG_LEVEL_OFF}"  # keep trace output silent
+    __BASHIO_LOG_LEVEL="${__BASHIO_LOG_LEVEL_OFF}" # keep trace output silent
     __BASHIO_LOG_FORMAT="[{TIMESTAMP}] {LEVEL}: {MESSAGE}"
     __BASHIO_LOG_TIMESTAMP="%T"
 }
@@ -63,7 +63,7 @@ setup() {
     before="$(date +%s)"
     run bashio::net.wait_for 19997 127.0.0.1 2
     after="$(date +%s)"
-    elapsed=$(( after - before ))
+    elapsed=$((after - before))
     [ "${status}" -eq "${__BASHIO_EXIT_OK}" ]
     # Must finish well inside the 2-second window (allow 5 s for slow CI).
     [ "${elapsed}" -lt 5 ]


### PR DESCRIPTION
# Proposed Changes

Per-module test coverage (part of a parallel batch), adding `lib/net.sh` with 5 tests.

The suite exercises each function with meaningful cases, not happy-path only. For API-backed modules the Supervisor boundary (`bashio::api.supervisor`) is stubbed to assert the correct method, endpoint, and jq filter are forwarded, the returned value, error/failure propagation, and the caching path where applicable. For logic modules it covers the real behaviour and both branches of conditionals. Where a function does not currently propagate API failures, the test documents the actual behaviour rather than asserting a contract that does not exist.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for network port availability checking functionality, including timeout scenarios, unreachable ports, and successful connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->