### PR TITLE
Add test coverage for lib/services.sh

### DIFF
--- a/tests/services.bats
+++ b/tests/services.bats
@@ -32,11 +32,13 @@ setup() {
 
 @test "services calls GET /services/<name>" {
     bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
         printf '%s' "${SERVICE_JSON}"
     }
     run bashio::services "mqtt"
     [ "${status}" -eq 0 ]
     [ "${output}" = "${SERVICE_JSON}" ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /services/mqtt false" ]
 }
 
 @test "services extracts a string field by key" {
@@ -60,7 +62,7 @@ setup() {
     [ "${output}" = "false" ]
 }
 
-@test "services returns empty for a null field" {
+@test "services returns the literal null for a null field" {
     bashio::api.supervisor() {
         printf '%s' '{"host":null}'
     }
@@ -126,8 +128,15 @@ setup() {
     # Call both without `run` so the cache state is shared.
     bashio::services "mqtt" >/dev/null
     bashio::services "mqtt" "host" >/dev/null
-    # Second call must be served from cache.
+    # Second call for the same service must be served from cache.
     [ "$(cat "${call_file}")" -eq 1 ]
+
+    # A different service must not collide with the first cache entry, so it
+    # triggers a fresh API call and gets its own cache file.
+    bashio::services "mysql" >/dev/null
+    [ "$(cat "${call_file}")" -eq 2 ]
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mysql.cache" ]
 }
 
 @test "services propagates an API failure" {
@@ -180,13 +189,21 @@ setup() {
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
 
-@test "services.publish returns success even when the API call fails" {
-    # bashio::services.publish does not check the API return code; it always
-    # flushes the cache and returns whatever the flush returns (success by
-    # default). The test documents this existing behaviour.
+@test "services.publish flushes the cache even when the API call fails" {
+    # bashio::services.publish does not check the API return code; it calls
+    # bashio::cache.flush_all after the API call regardless of its outcome.
+    # When errexit is suppressed (as it is under `run`), the failing API call
+    # does not abort the function, so the flush is still observed.
+    # Prime the cache first.
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    bashio::services "mqtt" >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
+
+    # Now publish with a failing API stub; the cache must still be flushed.
     bashio::api.supervisor() { return 1; }
     run bashio::services.publish "mqtt" '{"host":"x"}'
-    [ "${status}" -eq 0 ]
+    [ ! -e "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -214,11 +231,19 @@ setup() {
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
 
-@test "services.delete returns success even when the API call fails" {
-    # bashio::services.delete does not check the API return code; it always
-    # flushes the cache and returns whatever the flush returns (success by
-    # default). The test documents this existing behaviour.
+@test "services.delete flushes the cache even when the API call fails" {
+    # bashio::services.delete does not check the API return code; it calls
+    # bashio::cache.flush_all after the API call regardless of its outcome.
+    # When errexit is suppressed (as it is under `run`), the failing API call
+    # does not abort the function, so the flush is still observed.
+    # Prime the cache first.
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    bashio::services "mqtt" >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
+
+    # Now delete with a failing API stub; the cache must still be flushed.
     bashio::api.supervisor() { return 1; }
     run bashio::services.delete "mqtt"
-    [ "${status}" -eq 0 ]
+    [ ! -e "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
 }

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -1,0 +1,224 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/services.sh.
+#
+# The Supervisor API boundary is stubbed via a `bashio::api.supervisor` bash
+# function so no real HTTP requests are made. The cache is isolated to a
+# per-test temporary directory.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+# ---------------------------------------------------------------------------
+# Canned JSON response used by most tests
+# ---------------------------------------------------------------------------
+SERVICE_JSON='{
+  "host": "mqtt.local",
+  "port": 1883,
+  "ssl": false,
+  "username": "testuser",
+  "password": "testpass",
+  "protocol": "3.1.1",
+  "addon": "core_mosquitto"
+}'
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# ---------------------------------------------------------------------------
+# bashio::services - base fetcher
+# ---------------------------------------------------------------------------
+
+@test "services calls GET /services/<name>" {
+    bashio::api.supervisor() {
+        printf '%s' "${SERVICE_JSON}"
+    }
+    run bashio::services "mqtt"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "${SERVICE_JSON}" ]
+}
+
+@test "services extracts a string field by key" {
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    run bashio::services "mqtt" "host"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "mqtt.local" ]
+}
+
+@test "services extracts a numeric field by key" {
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    run bashio::services "mqtt" "port"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1883" ]
+}
+
+@test "services extracts a boolean field by key" {
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    run bashio::services "mqtt" "ssl"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+}
+
+@test "services returns empty for a null field" {
+    bashio::api.supervisor() {
+        printf '%s' '{"host":null}'
+    }
+    run bashio::services "mqtt" "host"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "null" ]
+}
+
+@test "services returns empty output for an empty string field" {
+    bashio::api.supervisor() {
+        printf '%s' '{"host":""}'
+    }
+    run bashio::services "mqtt" "host"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "" ]
+}
+
+@test "services returns each element of an array field" {
+    bashio::api.supervisor() {
+        printf '%s' '{"tags":["a","b","c"]}'
+    }
+    run bashio::services "mqtt" "tags"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"a"* ]]
+    [[ "${output}" == *"b"* ]]
+    [[ "${output}" == *"c"* ]]
+}
+
+@test "services returns empty output for an empty array field" {
+    bashio::api.supervisor() {
+        printf '%s' '{"tags":[]}'
+    }
+    run bashio::services "mqtt" "tags"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "" ]
+}
+
+@test "services returns an object field as-is" {
+    bashio::api.supervisor() {
+        printf '%s' '{"config":{"key":"val"}}'
+    }
+    run bashio::services "mqtt" "config"
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.key')" = "val" ]
+}
+
+@test "services returns empty output for an empty object field" {
+    bashio::api.supervisor() {
+        printf '%s' '{"config":{}}'
+    }
+    run bashio::services "mqtt" "config"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "" ]
+}
+
+@test "services uses a cache key per service name" {
+    local call_file="${BATS_TEST_TMPDIR}/calls"
+    printf '0' >"${call_file}"
+    bashio::api.supervisor() {
+        printf '%d' $(( $(cat "${call_file}") + 1 )) >"${call_file}"
+        printf '%s' "${SERVICE_JSON}"
+    }
+    # Call both without `run` so the cache state is shared.
+    bashio::services "mqtt" >/dev/null
+    bashio::services "mqtt" "host" >/dev/null
+    # Second call must be served from cache.
+    [ "$(cat "${call_file}")" -eq 1 ]
+}
+
+@test "services propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::services "mqtt" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::services.available
+# ---------------------------------------------------------------------------
+
+@test "services.available returns success when the API call succeeds" {
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    run bashio::services.available "mqtt"
+    [ "${status}" -eq 0 ]
+}
+
+@test "services.available returns failure when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::services.available "mqtt"
+    [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::services.publish
+# ---------------------------------------------------------------------------
+
+@test "services.publish calls POST /services/<name> with the config" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    bashio::cache.flush_all
+    run bashio::services.publish "mqtt" '{"host":"broker.local"}'
+    [ "${status}" -eq 0 ]
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [[ "${call}" == *"POST"* ]]
+    [[ "${call}" == *"/services/mqtt"* ]]
+    [[ "${call}" == *'{"host":"broker.local"}'* ]]
+}
+
+@test "services.publish flushes the cache" {
+    # Prime the cache first.
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    bashio::services "mqtt" >/dev/null
+    [ -f "${BATS_TEST_TMPDIR}/cache/service.info.mqtt.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::services.publish "mqtt" '{"host":"new"}'
+    # Cache directory must be gone after publish.
+    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+}
+
+@test "services.publish returns success even when the API call fails" {
+    # bashio::services.publish does not check the API return code; it always
+    # flushes the cache and returns whatever the flush returns (success by
+    # default). The test documents this existing behaviour.
+    bashio::api.supervisor() { return 1; }
+    run bashio::services.publish "mqtt" '{"host":"x"}'
+    [ "${status}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::services.delete
+# ---------------------------------------------------------------------------
+
+@test "services.delete calls DELETE /services/<name>" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::services.delete "mqtt"
+    [ "${status}" -eq 0 ]
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [[ "${call}" == *"DELETE"* ]]
+    [[ "${call}" == *"/services/mqtt"* ]]
+}
+
+@test "services.delete flushes the cache" {
+    # Prime the cache first.
+    bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
+    bashio::services "mqtt" >/dev/null
+    [ -f "${BATS_TEST_TMPDIR}/cache/service.info.mqtt.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::services.delete "mqtt"
+    # Cache directory must be gone after delete.
+    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+}
+
+@test "services.delete returns success even when the API call fails" {
+    # bashio::services.delete does not check the API return code; it always
+    # flushes the cache and returns whatever the flush returns (success by
+    # default). The test documents this existing behaviour.
+    bashio::api.supervisor() { return 1; }
+    run bashio::services.delete "mqtt"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -86,9 +86,10 @@ setup() {
     }
     run bashio::services "mqtt" "tags"
     [ "${status}" -eq 0 ]
-    [[ "${output}" == *"a"* ]]
-    [[ "${output}" == *"b"* ]]
-    [[ "${output}" == *"c"* ]]
+    [ "${#lines[@]}" -eq 3 ]
+    [ "${lines[0]}" = "a" ]
+    [ "${lines[1]}" = "b" ]
+    [ "${lines[2]}" = "c" ]
 }
 
 @test "services returns empty output for an empty array field" {
@@ -122,7 +123,9 @@ setup() {
     local call_file="${BATS_TEST_TMPDIR}/calls"
     printf '0' >"${call_file}"
     bashio::api.supervisor() {
-        printf '%d' $(($(cat "${call_file}") + 1)) >"${call_file}"
+        local count
+        count=$(cat "${call_file}")
+        printf '%d' "$((count + 1))" >"${call_file}"
         printf '%s' "${SERVICE_JSON}"
     }
     # Call both without `run` so the cache state is shared.

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -172,21 +172,19 @@ setup() {
     run bashio::services.publish "mqtt" '{"host":"broker.local"}'
     [ "${status}" -eq 0 ]
     call="$(cat "${BATS_TEST_TMPDIR}/call")"
-    [[ "${call}" == *"POST"* ]]
-    [[ "${call}" == *"/services/mqtt"* ]]
-    [[ "${call}" == *'{"host":"broker.local"}'* ]]
+    [ "${call}" = 'POST /services/mqtt {"host":"broker.local"}' ]
 }
 
 @test "services.publish flushes the cache" {
     # Prime the cache first.
     bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
     bashio::services "mqtt" >/dev/null
-    [ -f "${BATS_TEST_TMPDIR}/cache/service.info.mqtt.cache" ]
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
 
     bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
     bashio::services.publish "mqtt" '{"host":"new"}'
     # Cache directory must be gone after publish.
-    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
 }
 
 @test "services.publish flushes the cache even when the API call fails" {
@@ -215,20 +213,19 @@ setup() {
     run bashio::services.delete "mqtt"
     [ "${status}" -eq 0 ]
     call="$(cat "${BATS_TEST_TMPDIR}/call")"
-    [[ "${call}" == *"DELETE"* ]]
-    [[ "${call}" == *"/services/mqtt"* ]]
+    [ "${call}" = "DELETE /services/mqtt" ]
 }
 
 @test "services.delete flushes the cache" {
     # Prime the cache first.
     bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
     bashio::services "mqtt" >/dev/null
-    [ -f "${BATS_TEST_TMPDIR}/cache/service.info.mqtt.cache" ]
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
 
     bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
     bashio::services.delete "mqtt"
     # Cache directory must be gone after delete.
-    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
 }
 
 @test "services.delete flushes the cache even when the API call fails" {

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -120,7 +120,7 @@ setup() {
     local call_file="${BATS_TEST_TMPDIR}/calls"
     printf '0' >"${call_file}"
     bashio::api.supervisor() {
-        printf '%d' $(( $(cat "${call_file}") + 1 )) >"${call_file}"
+        printf '%d' $(($(cat "${call_file}") + 1)) >"${call_file}"
         printf '%s' "${SERVICE_JSON}"
     }
     # Call both without `run` so the cache state is shared.


### PR DESCRIPTION
# Proposed Changes

Per-module test coverage (part of a parallel batch), adding `lib/services.sh` with 20 tests.

The suite exercises each function with meaningful cases, not happy-path only. For API-backed modules the Supervisor boundary (`bashio::api.supervisor`) is stubbed to assert the correct method, endpoint, and jq filter are forwarded, the returned value, error/failure propagation, and the caching path where applicable. For logic modules it covers the real behaviour and both branches of conditionals. Where a function does not currently propagate API failures, the test documents the actual behaviour rather than asserting a contract that does not exist.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for services functionality, including API request validation, response handling for various data types, caching behavior, and service management operations (availability checks, publishing, and deletion).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->