### PR TITLE
Add test coverage for lib/discovery.sh

### DIFF
--- a/tests/discovery.bats
+++ b/tests/discovery.bats
@@ -71,12 +71,20 @@ setup() {
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
 
-@test "discovery returns success even when the API call fails" {
-    # bashio::discovery does not check the API return code; it always flushes
-    # the cache and returns success. The test documents this existing behaviour.
+@test "discovery masks API failure: cache is flushed and exit status is 0" {
+    # bashio::discovery does not propagate the API return code. The trailing
+    # bashio::cache.flush_all call masks any prior failure, so the overall
+    # function always returns 0. Prime a cache entry to confirm the flush
+    # still runs even when the API call fails.
+    bashio::cache.set "some.key" "before-failure"
+    [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
+
     bashio::api.supervisor() { return 1; }
-    run bashio::discovery "mqtt" '{"host":"x"}'
-    [ "${status}" -eq 0 ]
+    rc=0
+    bashio::discovery "mqtt" '{"host":"x"}' >/dev/null || rc=$?
+    [ "${rc}" -eq 0 ]
+    # The cache must be gone, proving flush_all ran despite the API failure.
+    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -108,11 +116,18 @@ setup() {
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
 
-@test "discovery.delete returns success even when the API call fails" {
-    # bashio::discovery.delete does not check the API return code; it always
-    # flushes the cache and returns success. The test documents this existing
-    # behaviour.
+@test "discovery.delete masks API failure: cache is flushed and exit status is 0" {
+    # bashio::discovery.delete does not propagate the API return code. The
+    # trailing bashio::cache.flush_all call masks any prior failure, so the
+    # overall function always returns 0. Prime a cache entry to confirm the
+    # flush still runs even when the API call fails.
+    bashio::cache.set "some.key" "before-failure"
+    [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
+
     bashio::api.supervisor() { return 1; }
-    run bashio::discovery.delete "abc-def-uuid"
-    [ "${status}" -eq 0 ]
+    rc=0
+    bashio::discovery.delete "abc-def-uuid" || rc=$?
+    [ "${rc}" -eq 0 ]
+    # The cache must be gone, proving flush_all ran despite the API failure.
+    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }

--- a/tests/discovery.bats
+++ b/tests/discovery.bats
@@ -18,17 +18,23 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "discovery calls POST /discovery with service and config payload" {
+    # Capture the exact argument string so method, resource, payload and filter
+    # are all validated in their correct positions, not as loose substrings.
     bashio::api.supervisor() {
         printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
         printf '%s' '"abc-uuid"'
     }
+    # Build the exact payload the function is expected to send, using the same
+    # helper, so the comparison stays robust to JSON key ordering.
+    expected_payload=$(
+        bashio::var.json \
+            service "mqtt" \
+            config "^"'{"host":"broker.local","port":1883}'
+    )
     run bashio::discovery "mqtt" '{"host":"broker.local","port":1883}'
     [ "${status}" -eq 0 ]
     call="$(cat "${BATS_TEST_TMPDIR}/call")"
-    [[ "${call}" == *"POST"* ]]
-    [[ "${call}" == *"/discovery"* ]]
-    # The filter for the uuid must be forwarded.
-    [[ "${call}" == *".uuid"* ]]
+    [ "${call}" = "POST /discovery ${expected_payload} .uuid" ]
 }
 
 @test "discovery payload contains service name" {
@@ -72,17 +78,24 @@ setup() {
 }
 
 @test "discovery masks API failure: cache is flushed and exit status is 0" {
-    # bashio::discovery does not propagate the API return code. The trailing
-    # bashio::cache.flush_all call masks any prior failure, so the overall
-    # function always returns 0. Prime a cache entry to confirm the flush
-    # still runs even when the API call fails.
+    # bashio::discovery does not propagate the API return code: its return
+    # status is whatever bashio::cache.flush_all returns. An API failure is
+    # only masked when the caller suppresses errexit (as here, with `|| rc=$?`).
+    # Prime a cache entry to confirm the flush still runs even when the API
+    # call fails, and record the call so we can prove the API was attempted.
     bashio::cache.set "some.key" "before-failure"
     [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
 
-    bashio::api.supervisor() { return 1; }
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
     rc=0
     bashio::discovery "mqtt" '{"host":"x"}' >/dev/null || rc=$?
     [ "${rc}" -eq 0 ]
+    # The failing Supervisor call must still have been attempted.
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [[ "${call}" == "POST /discovery "* ]]
     # The cache must be gone, proving flush_all ran despite the API failure.
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
@@ -92,12 +105,13 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "discovery.delete calls DELETE /discovery/<uuid>" {
+    # Capture the exact argument string so method and resource path are
+    # validated in their correct positions, not as loose substrings.
     bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
     run bashio::discovery.delete "abc-def-uuid"
     [ "${status}" -eq 0 ]
     call="$(cat "${BATS_TEST_TMPDIR}/call")"
-    [[ "${call}" == *"DELETE"* ]]
-    [[ "${call}" == *"/discovery/abc-def-uuid"* ]]
+    [ "${call}" = "DELETE /discovery/abc-def-uuid" ]
 }
 
 @test "discovery.delete passes the uuid in the path" {
@@ -117,17 +131,24 @@ setup() {
 }
 
 @test "discovery.delete masks API failure: cache is flushed and exit status is 0" {
-    # bashio::discovery.delete does not propagate the API return code. The
-    # trailing bashio::cache.flush_all call masks any prior failure, so the
-    # overall function always returns 0. Prime a cache entry to confirm the
-    # flush still runs even when the API call fails.
+    # bashio::discovery.delete does not propagate the API return code: its
+    # return status is whatever bashio::cache.flush_all returns. An API failure
+    # is only masked when the caller suppresses errexit (as here, with
+    # `|| rc=$?`). Prime a cache entry to confirm the flush still runs even when
+    # the API call fails, and record the call so we can prove it was attempted.
     bashio::cache.set "some.key" "before-failure"
     [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
 
-    bashio::api.supervisor() { return 1; }
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
     rc=0
     bashio::discovery.delete "abc-def-uuid" || rc=$?
     [ "${rc}" -eq 0 ]
+    # The failing Supervisor call must still have been attempted.
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [ "${call}" = "DELETE /discovery/abc-def-uuid" ]
     # The cache must be gone, proving flush_all ran despite the API failure.
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }

--- a/tests/discovery.bats
+++ b/tests/discovery.bats
@@ -22,7 +22,7 @@ setup() {
     # are all validated in their correct positions, not as loose substrings.
     bashio::api.supervisor() {
         printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
-        printf '%s' '"abc-uuid"'
+        printf '%s' 'abc-uuid'
     }
     # Build the exact payload the function is expected to send, using the same
     # helper, so the comparison stays robust to JSON key ordering.
@@ -41,7 +41,7 @@ setup() {
     bashio::api.supervisor() {
         # Write the payload argument (3rd positional) to a file for inspection.
         printf '%s' "$3" >"${BATS_TEST_TMPDIR}/payload"
-        printf '%s' '"test-uuid"'
+        printf '%s' 'test-uuid'
     }
     bashio::discovery "myservice" '{"key":"value"}' >/dev/null
     payload="$(cat "${BATS_TEST_TMPDIR}/payload")"
@@ -51,7 +51,7 @@ setup() {
 @test "discovery payload embeds the config object" {
     bashio::api.supervisor() {
         printf '%s' "$3" >"${BATS_TEST_TMPDIR}/payload"
-        printf '%s' '"test-uuid"'
+        printf '%s' 'test-uuid'
     }
     bashio::discovery "myservice" '{"host":"broker.local","port":1883}' >/dev/null
     payload="$(cat "${BATS_TEST_TMPDIR}/payload")"
@@ -71,7 +71,7 @@ setup() {
     bashio::cache.set "some.key" "some.value"
     [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
 
-    bashio::api.supervisor() { printf '%s' '"new-uuid"'; }
+    bashio::api.supervisor() { printf '%s' 'new-uuid'; }
     bashio::discovery "mqtt" '{"host":"x"}' >/dev/null
     # Cache directory must be gone after publish.
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]

--- a/tests/discovery.bats
+++ b/tests/discovery.bats
@@ -18,7 +18,10 @@ setup() {
 # ---------------------------------------------------------------------------
 
 @test "discovery calls POST /discovery with service and config payload" {
-    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; printf '%s' '"abc-uuid"'; }
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '"abc-uuid"'
+    }
     run bashio::discovery "mqtt" '{"host":"broker.local","port":1883}'
     [ "${status}" -eq 0 ]
     call="$(cat "${BATS_TEST_TMPDIR}/call")"

--- a/tests/discovery.bats
+++ b/tests/discovery.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/discovery.sh.
+#
+# The Supervisor API boundary is stubbed via a `bashio::api.supervisor` bash
+# function so no real HTTP requests are made. The cache is isolated to a
+# per-test temporary directory.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# ---------------------------------------------------------------------------
+# bashio::discovery
+# ---------------------------------------------------------------------------
+
+@test "discovery calls POST /discovery with service and config payload" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; printf '%s' '"abc-uuid"'; }
+    run bashio::discovery "mqtt" '{"host":"broker.local","port":1883}'
+    [ "${status}" -eq 0 ]
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [[ "${call}" == *"POST"* ]]
+    [[ "${call}" == *"/discovery"* ]]
+    # The filter for the uuid must be forwarded.
+    [[ "${call}" == *".uuid"* ]]
+}
+
+@test "discovery payload contains service name" {
+    bashio::api.supervisor() {
+        # Write the payload argument (3rd positional) to a file for inspection.
+        printf '%s' "$3" >"${BATS_TEST_TMPDIR}/payload"
+        printf '%s' '"test-uuid"'
+    }
+    bashio::discovery "myservice" '{"key":"value"}' >/dev/null
+    payload="$(cat "${BATS_TEST_TMPDIR}/payload")"
+    [ "$(printf '%s' "${payload}" | jq -r '.service')" = "myservice" ]
+}
+
+@test "discovery payload embeds the config object" {
+    bashio::api.supervisor() {
+        printf '%s' "$3" >"${BATS_TEST_TMPDIR}/payload"
+        printf '%s' '"test-uuid"'
+    }
+    bashio::discovery "myservice" '{"host":"broker.local","port":1883}' >/dev/null
+    payload="$(cat "${BATS_TEST_TMPDIR}/payload")"
+    [ "$(printf '%s' "${payload}" | jq -r '.config.host')" = "broker.local" ]
+    [ "$(printf '%s' "${payload}" | jq -r '.config.port')" = "1883" ]
+}
+
+@test "discovery returns the uuid from the API response" {
+    bashio::api.supervisor() { printf '%s' 'abc-def-uuid'; }
+    run bashio::discovery "mqtt" '{"host":"x"}'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "abc-def-uuid" ]
+}
+
+@test "discovery flushes the cache after publishing" {
+    # Prime the cache first with a dummy key.
+    bashio::cache.set "some.key" "some.value"
+    [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
+
+    bashio::api.supervisor() { printf '%s' '"new-uuid"'; }
+    bashio::discovery "mqtt" '{"host":"x"}' >/dev/null
+    # Cache directory must be gone after publish.
+    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+}
+
+@test "discovery returns success even when the API call fails" {
+    # bashio::discovery does not check the API return code; it always flushes
+    # the cache and returns success. The test documents this existing behaviour.
+    bashio::api.supervisor() { return 1; }
+    run bashio::discovery "mqtt" '{"host":"x"}'
+    [ "${status}" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::discovery.delete
+# ---------------------------------------------------------------------------
+
+@test "discovery.delete calls DELETE /discovery/<uuid>" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::discovery.delete "abc-def-uuid"
+    [ "${status}" -eq 0 ]
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [[ "${call}" == *"DELETE"* ]]
+    [[ "${call}" == *"/discovery/abc-def-uuid"* ]]
+}
+
+@test "discovery.delete passes the uuid in the path" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    bashio::discovery.delete "some-other-uuid"
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [[ "${call}" == *"/discovery/some-other-uuid"* ]]
+}
+
+@test "discovery.delete flushes the cache" {
+    bashio::cache.set "some.key" "some.value"
+    [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::discovery.delete "abc-def-uuid"
+    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+}
+
+@test "discovery.delete returns success even when the API call fails" {
+    # bashio::discovery.delete does not check the API return code; it always
+    # flushes the cache and returns success. The test documents this existing
+    # behaviour.
+    bashio::api.supervisor() { return 1; }
+    run bashio::discovery.delete "abc-def-uuid"
+    [ "${status}" -eq 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

Per-module test coverage (part of a parallel batch), adding `lib/discovery.sh` with 10 tests.

The suite exercises each function with meaningful cases, not happy-path only. For API-backed modules the Supervisor boundary (`bashio::api.supervisor`) is stubbed to assert the correct method, endpoint, and jq filter are forwarded, the returned value, error/failure propagation, and the caching path where applicable. For logic modules it covers the real behaviour and both branches of conditionals. Where a function does not currently propagate API failures, the test documents the actual behaviour rather than asserting a contract that does not exist.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for discovery functionality, including tests for API requests, response handling, cache management, and error scenarios to improve code reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->