### PR TITLE
Expand test coverage for lib/audio.sh

### DIFF
--- a/tests/audio.bats
+++ b/tests/audio.bats
@@ -1,6 +1,10 @@
 #!/usr/bin/env bats
 # ==============================================================================
 # Tests for lib/audio.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# audio fetchers, jq filtering, and caching run. The cache is pointed at a
+# per-test temporary directory so tests stay isolated.
 # ==============================================================================
 
 source "${BATS_TEST_DIRNAME}/test_helper.bash"
@@ -9,9 +13,282 @@ setup() {
     __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
 }
 
+# ------------------------------------------------------------------------------
+# bashio::audio.update
+# ------------------------------------------------------------------------------
+
+@test "audio.update without a version posts to the update endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.update
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /audio/update" ]
+}
+
+@test "audio.update with a version forwards it as a JSON object" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.update "1.2.3"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/update {"version":"1.2.3"}' ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.reload (preserved + expanded)
+# ------------------------------------------------------------------------------
+
+@test "audio.reload calls the reload endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.reload
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /audio/reload" ]
+}
+
 @test "audio.reload propagates an API failure" {
     bashio::api.supervisor() { return 1; }
     rc=0
     bashio::audio.reload || rc=$?
     [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.restart
+# ------------------------------------------------------------------------------
+
+@test "audio.restart calls the restart endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.restart
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /audio/restart" ]
+}
+
+@test "audio.restart propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.restart || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.logs
+# ------------------------------------------------------------------------------
+
+@test "audio.logs requests the logs endpoint in raw mode" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.logs
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /audio/logs true" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio (info fetcher)
+# ------------------------------------------------------------------------------
+
+@test "audio fetches info from the API and returns the raw object" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"version":"1.0","host":"172.30.32.1"}'
+    }
+    run bashio::audio
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /audio/info false" ]
+    [ "${output}" = '{"version":"1.0","host":"172.30.32.1"}' ]
+}
+
+@test "audio applies a jq filter when provided" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"1.0","host":"172.30.32.1"}'
+    }
+    run bashio::audio 'audio.custom' '.host'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "172.30.32.1" ]
+}
+
+@test "audio serves a cached value without calling the API" {
+    bashio::api.supervisor() { return 1; }
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    bashio::cache.set 'audio.info' '{"version":"9.9"}'
+    run bashio::audio
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"version":"9.9"}' ]
+}
+
+@test "audio propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.version
+# ------------------------------------------------------------------------------
+
+@test "audio.version extracts the version from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"1.0","version_latest":"2.0"}'
+    }
+    run bashio::audio.version
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1.0" ]
+}
+
+@test "audio.version propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.version || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.version_latest
+# ------------------------------------------------------------------------------
+
+@test "audio.version_latest extracts the latest version from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"1.0","version_latest":"2.0"}'
+    }
+    run bashio::audio.version_latest
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2.0" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.update_available
+# ------------------------------------------------------------------------------
+
+@test "audio.update_available returns the update flag" {
+    bashio::api.supervisor() {
+        printf '%s' '{"update_available":true}'
+    }
+    run bashio::audio.update_available
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "audio.update_available defaults to false when absent" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"1.0"}'
+    }
+    run bashio::audio.update_available
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.host
+# ------------------------------------------------------------------------------
+
+@test "audio.host extracts the host from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"host":"172.30.32.1"}'
+    }
+    run bashio::audio.host
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "172.30.32.1" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.stats (stats fetcher)
+# ------------------------------------------------------------------------------
+
+@test "audio.stats fetches stats from the API and returns the raw object" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"cpu_percent":1.5,"memory_usage":1024}'
+    }
+    run bashio::audio.stats
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /audio/stats false" ]
+    [ "${output}" = '{"cpu_percent":1.5,"memory_usage":1024}' ]
+}
+
+@test "audio.stats applies a jq filter when provided" {
+    bashio::api.supervisor() {
+        printf '%s' '{"cpu_percent":1.5,"memory_usage":1024}'
+    }
+    run bashio::audio.stats 'audio.custom' '.cpu_percent'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1.5" ]
+}
+
+@test "audio.stats propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.stats || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# stats accessors
+# ------------------------------------------------------------------------------
+
+@test "audio.cpu_percent extracts the cpu_percent stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"cpu_percent":2.5,"memory_usage":1,"memory_limit":2,"memory_percent":3,"network_tx":4,"network_rx":5,"blk_read":6,"blk_write":7}'
+    }
+    run bashio::audio.cpu_percent
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2.5" ]
+}
+
+@test "audio.memory_usage extracts the memory_usage stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"memory_usage":1024}'
+    }
+    run bashio::audio.memory_usage
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1024" ]
+}
+
+@test "audio.memory_limit extracts the memory_limit stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"memory_limit":2048}'
+    }
+    run bashio::audio.memory_limit
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2048" ]
+}
+
+@test "audio.memory_percent extracts the memory_percent stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"memory_percent":42}'
+    }
+    run bashio::audio.memory_percent
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "42" ]
+}
+
+@test "audio.network_tx extracts the network_tx stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"network_tx":100}'
+    }
+    run bashio::audio.network_tx
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "100" ]
+}
+
+@test "audio.network_rx extracts the network_rx stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"network_rx":200}'
+    }
+    run bashio::audio.network_rx
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "200" ]
+}
+
+@test "audio.blk_read extracts the blk_read stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"blk_read":300}'
+    }
+    run bashio::audio.blk_read
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "300" ]
+}
+
+@test "audio.blk_write extracts the blk_write stat" {
+    bashio::api.supervisor() {
+        printf '%s' '{"blk_write":400}'
+    }
+    run bashio::audio.blk_write
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "400" ]
 }


### PR DESCRIPTION
# Proposed Changes

Per-module test coverage (part of a parallel batch), expanding `lib/audio.sh` with 28 tests.

The suite exercises each function with meaningful cases, not happy-path only. For API-backed modules the Supervisor boundary (`bashio::api.supervisor`) is stubbed to assert the correct method, endpoint, and jq filter are forwarded, the returned value, error/failure propagation, and the caching path where applicable. For logic modules it covers the real behaviour and both branches of conditionals. Where a function does not currently propagate API failures, the test documents the actual behaviour rather than asserting a contract that does not exist.

## Related Issues

>