### PR TITLE
Expand test coverage for lib/os.sh

### DIFF
--- a/tests/os.bats
+++ b/tests/os.bats
@@ -1,6 +1,12 @@
 #!/usr/bin/env bats
 # ==============================================================================
 # Tests for lib/os.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::os` fetcher, jq filtering, and caching run. The cache is pointed at a
+# per-test temporary directory so tests stay isolated. The update action and the
+# config_sync action are checked for correct method/resource forwarding, the
+# getters for the value they return, and the actions for error propagation.
 # ==============================================================================
 
 source "${BATS_TEST_DIRNAME}/test_helper.bash"
@@ -9,9 +15,182 @@ setup() {
     __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
 }
 
+# ------------------------------------------------------------------------------
+# os.update: posts (optionally) a version and flushes the cache.
+# ------------------------------------------------------------------------------
+
+@test "os.update posts to the update endpoint without a version" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.update
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /os/update" ]
+}
+
+@test "os.update posts the version as JSON options when supplied" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.update "12.0"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /os/update {"version":"12.0"}' ]
+}
+
+@test "os.update flushes the cache after a successful update" {
+    bashio::cache.set 'os.info' '{"version":"11.0"}'
+    bashio::api.supervisor() { return 0; }
+    run bashio::os.update "12.0"
+    [ "${status}" -eq 0 ]
+    run bashio::cache.exists 'os.info'
+    [ "${status}" -ne 0 ]
+}
+
 @test "os.update propagates an API failure" {
     bashio::api.supervisor() { return 1; }
     rc=0
     bashio::os.update || rc=$?
     [ "${rc}" -ne 0 ]
+}
+
+@test "os.update propagates an API failure when a version is supplied" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.update "12.0" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# os.config_sync action.
+# ------------------------------------------------------------------------------
+
+@test "os.config_sync posts to the config sync endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.config_sync
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /os/config/sync" ]
+}
+
+@test "os.config_sync propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::os.config_sync
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# Core fetcher: bashio::os.
+# ------------------------------------------------------------------------------
+
+@test "os fetches info from the API with the correct method and resource" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"version":"12.0"}'
+    }
+    run bashio::os
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /os/info false" ]
+    [ "${output}" = '{"version":"12.0"}' ]
+}
+
+@test "os applies the supplied jq filter to the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"12.0","board":"rpi4"}'
+    }
+    run bashio::os 'os.info.board' '.board'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "rpi4" ]
+}
+
+@test "os returns a cached value without calling the API" {
+    bashio::cache.set 'my.key' 'cached-value'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os 'my.key'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-value" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "os reuses cached os.info instead of refetching" {
+    bashio::cache.set 'os.info' '{"version":"cached-version"}'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os 'os.info.version' '.version'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-version" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "os caches the filtered response under the cache key" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"12.0"}'
+    }
+    bashio::os 'os.info.version' '.version' >/dev/null
+    run bashio::cache.get 'os.info.version'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "12.0" ]
+}
+
+@test "os fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::os
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# Simple getters: each forwards a fixed cache key and jq filter.
+# ------------------------------------------------------------------------------
+
+@test "os.version returns the version" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"12.0"}'
+    }
+    run bashio::os.version
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "12.0" ]
+}
+
+@test "os.version_latest returns the latest version" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version_latest":"12.1"}'
+    }
+    run bashio::os.version_latest
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "12.1" ]
+}
+
+@test "os.update_available returns true when an update is available" {
+    bashio::api.supervisor() {
+        printf '%s' '{"update_available":true}'
+    }
+    run bashio::os.update_available
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "os.update_available defaults to false when the field is absent" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"12.0"}'
+    }
+    run bashio::os.update_available
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+}
+
+@test "os.board returns the board" {
+    bashio::api.supervisor() {
+        printf '%s' '{"board":"rpi4"}'
+    }
+    run bashio::os.board
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "rpi4" ]
+}
+
+@test "os.boot returns the active boot slot" {
+    bashio::api.supervisor() {
+        printf '%s' '{"boot":"A"}'
+    }
+    run bashio::os.boot
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "A" ]
+}
+
+@test "os.version propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::os.version
+    [ "${status}" -ne 0 ]
 }


### PR DESCRIPTION
# Proposed Changes

Per-module test coverage (part of a parallel batch), expanding `lib/os.sh` with 20 tests.

The suite exercises each function with meaningful cases, not happy-path only. For API-backed modules the Supervisor boundary (`bashio::api.supervisor`) is stubbed to assert the correct method, endpoint, and jq filter are forwarded, the returned value, error/failure propagation, and the caching path where applicable. For logic modules it covers the real behaviour and both branches of conditionals. Where a function does not currently propagate API failures, the test documents the actual behaviour rather than asserting a contract that does not exist.

## Related Issues

>