### PR TITLE
Expand addons test coverage and fix the misnamed stats dispatch

### DIFF
--- a/lib/addons.sh
+++ b/lib/addons.sh
@@ -1368,7 +1368,7 @@ function bashio::addon.stats() {
 function bashio::addon.cpu_percent() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.cpu_percent" \
         '.cpu_percent'
@@ -1383,7 +1383,7 @@ function bashio::addon.cpu_percent() {
 function bashio::addon.memory_usage() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.memory_usage" \
         '.memory_usage'
@@ -1398,7 +1398,7 @@ function bashio::addon.memory_usage() {
 function bashio::addon.memory_limit() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.memory_limit" \
         '.memory_limit'
@@ -1413,7 +1413,7 @@ function bashio::addon.memory_limit() {
 function bashio::addon.memory_percent() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.memory_percent" \
         '.memory_percent'
@@ -1428,7 +1428,7 @@ function bashio::addon.memory_percent() {
 function bashio::addon.network_tx() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.network_tx" \
         '.network_tx'
@@ -1443,7 +1443,7 @@ function bashio::addon.network_tx() {
 function bashio::addon.network_rx() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.network_rx" \
         '.network_rx'
@@ -1458,7 +1458,7 @@ function bashio::addon.network_rx() {
 function bashio::addon.blk_read() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.blk_read" \
         '.blk_read'
@@ -1473,7 +1473,7 @@ function bashio::addon.blk_read() {
 function bashio::addon.blk_write() {
     local slug=${1:-'self'}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::addons.stats \
+    bashio::addon.stats \
         "${slug}" \
         "addons.${slug}.stats.blk_write" \
         '.blk_write'

--- a/tests/addons.bats
+++ b/tests/addons.bats
@@ -1,12 +1,42 @@
 #!/usr/bin/env bats
 # ==============================================================================
 # Tests for lib/addons.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::addons` fetcher, jq filtering, and caching run. The cache is pointed
+# at a per-test temporary directory so tests stay isolated. Stubs record their
+# arguments via "$*" and the assertions check the EXACT call string (method,
+# resource, filter/JSON), so they pin down the contract rather than fragments.
+#
+# A few setters end with `bashio::cache.flush_all`, which removes the cache
+# directory. Where a setter is exercised the cache dir is recreated implicitly
+# by the next `bashio::cache.set`, so tests do not rely on it surviving.
 # ==============================================================================
 
 source "${BATS_TEST_DIRNAME}/test_helper.bash"
 
 setup() {
     __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# A canned store listing used by the fetcher to determine the install state of
+# a slug, and the per-addon info responses returned afterwards.
+store_listing() {
+    printf '%s' '{"addons":[
+        {"slug":"alpha","installed":true},
+        {"slug":"beta","installed":false}
+    ]}'
+}
+
+# ------------------------------------------------------------------------------
+# Action helpers: simple POST/GET passthroughs.
+# ------------------------------------------------------------------------------
+
+@test "addons.reload posts to the reload endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addons.reload
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /addons/reload" ]
 }
 
 @test "addons.reload propagates an API failure" {
@@ -16,12 +46,825 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "addon.start posts to the start endpoint for a given slug" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.start "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /addons/example/start" ]
+}
+
+@test "addon.start defaults to the self slug" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.start
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /addons/self/start" ]
+}
+
+@test "addon.restart posts to the restart endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.restart "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /addons/example/restart" ]
+}
+
+@test "addon.stop posts to the stop endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.stop "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /addons/example/stop" ]
+}
+
+@test "addon.rebuild posts to the rebuild endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.rebuild "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /addons/example/rebuild" ]
+}
+
+@test "addon.install posts to the store install endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.install "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /store/addons/example/install" ]
+}
+
+@test "addon.install propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.install "example" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.uninstall posts to the uninstall endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.uninstall "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /addons/example/uninstall" ]
+}
+
+@test "addon.uninstall propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.uninstall "example" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.update posts to the store update endpoint for an explicit slug" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.update "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /store/addons/example/update" ]
+}
+
+@test "addon.update resolves self to a concrete slug before posting" {
+    # self is not valid on the store endpoint, so the resolver must swap it for
+    # the real slug obtained via addon.slug.
+    bashio::addon.slug() { printf '%s' "resolved_self"; }
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.update "self"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /store/addons/resolved_self/update" ]
+}
+
 @test "addon.update propagates an API failure" {
     bashio::api.supervisor() { return 1; }
     rc=0
     bashio::addon.update "example" || rc=$?
     [ "${rc}" -ne 0 ]
 }
+
+@test "addon.logs requests raw logs output" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.logs "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /addons/example/logs true" ]
+}
+
+@test "addon.documentation requests raw documentation for an explicit slug" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.documentation "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /addons/example/documentation true" ]
+}
+
+@test "addon.documentation resolves self before requesting" {
+    bashio::addon.slug() { printf '%s' "resolved_self"; }
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.documentation "self"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /addons/resolved_self/documentation true" ]
+}
+
+@test "addon.changelog requests raw changelog for an explicit slug" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.changelog "example"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /addons/example/changelog true" ]
+}
+
+@test "addon.changelog resolves self before requesting" {
+    bashio::addon.slug() { printf '%s' "resolved_self"; }
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.changelog "self"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /addons/resolved_self/changelog true" ]
+}
+
+# ------------------------------------------------------------------------------
+# The bashio::addons fetcher: list mode, slug mode, caching, filtering.
+# ------------------------------------------------------------------------------
+
+@test "addons lists every slug from the store listing" {
+    bashio::api.supervisor() { store_listing; }
+    run bashio::addons
+    [ "${status}" -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "alpha" ]
+    [ "${lines[1]}" = "beta" ]
+}
+
+@test "addons caches the unfiltered store listing as store.addons.info" {
+    bashio::api.supervisor() { store_listing; }
+    bashio::addons >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/store.addons.info.cache" ]
+    run jq -r '.addons | length' <"${__BASHIO_CACHE_DIR}/store.addons.info.cache"
+    [ "${output}" = "2" ]
+}
+
+@test "addons caches the filtered list under the default cache key" {
+    bashio::api.supervisor() { store_listing; }
+    bashio::addons >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/addons.list.cache" ]
+    run cat "${__BASHIO_CACHE_DIR}/addons.list.cache"
+    [ "${lines[0]}" = "alpha" ]
+    [ "${lines[1]}" = "beta" ]
+}
+
+@test "addons serves the filtered list from cache without hitting the API" {
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    printf '%s' "cached-value" >"${__BASHIO_CACHE_DIR}/addons.list.cache"
+    bashio::api.supervisor() {
+        echo "API SHOULD NOT BE CALLED"
+        return 1
+    }
+    run bashio::addons
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-value" ]
+}
+
+@test "addons reuses the cached store.addons.info instead of calling the API" {
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    store_listing >"${__BASHIO_CACHE_DIR}/store.addons.info.cache"
+    bashio::api.supervisor() {
+        echo "API SHOULD NOT BE CALLED"
+        return 1
+    }
+    run bashio::addons
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "alpha" ]
+    [ "${lines[1]}" = "beta" ]
+}
+
+@test "addons fails when the store listing API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addons >/dev/null || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addons for an installed slug fetches from the addons info endpoint" {
+    # The first call returns the store listing (alpha is installed), the second
+    # must therefore target the installed-addon info endpoint.
+    bashio::api.supervisor() {
+        echo "$*" >>"${BATS_TEST_TMPDIR}/calls"
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"alpha"}'
+        fi
+    }
+    run bashio::addons "alpha"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "alpha" ]
+    run cat "${BATS_TEST_TMPDIR}/calls"
+    [ "${lines[0]}" = "GET /store/addons false" ]
+    [ "${lines[1]}" = "GET /addons/alpha/info false" ]
+}
+
+@test "addons for an uninstalled slug fetches from the store addon endpoint" {
+    bashio::api.supervisor() {
+        echo "$*" >>"${BATS_TEST_TMPDIR}/calls"
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"beta"}'
+        fi
+    }
+    run bashio::addons "beta"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "beta" ]
+    run cat "${BATS_TEST_TMPDIR}/calls"
+    [ "${lines[1]}" = "GET /store/addons/beta false" ]
+}
+
+@test "addons for the self slug uses the installed info endpoint" {
+    # self is treated as installed without consulting the listing for state.
+    bashio::api.supervisor() {
+        echo "$*" >>"${BATS_TEST_TMPDIR}/calls"
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"selfslug"}'
+        fi
+    }
+    run bashio::addons "self"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "selfslug" ]
+    run cat "${BATS_TEST_TMPDIR}/calls"
+    [ "${lines[1]}" = "GET /addons/self/info false" ]
+}
+
+@test "addons applies a custom jq filter and caches under a custom key" {
+    bashio::api.supervisor() {
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"alpha","name":"Alpha App"}'
+        fi
+    }
+    run bashio::addons "alpha" "custom.key" '.name'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "Alpha App" ]
+    [ -f "${__BASHIO_CACHE_DIR}/custom.key.cache" ]
+    run cat "${__BASHIO_CACHE_DIR}/custom.key.cache"
+    [ "${output}" = "Alpha App" ]
+}
+
+@test "addons with filter false returns the raw info unfiltered" {
+    bashio::api.supervisor() {
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"alpha","name":"Alpha App"}'
+        fi
+    }
+    run bashio::addons "alpha" false false
+    [ "${status}" -eq 0 ]
+    run jq -r '.name' <<<"${output}"
+    [ "${output}" = "Alpha App" ]
+}
+
+@test "addons fails when the jq filter is invalid" {
+    bashio::api.supervisor() { store_listing; }
+    rc=0
+    bashio::addons false false '.[' >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# installed / self helpers.
+# ------------------------------------------------------------------------------
+
+@test "addons.installed lists only installed slugs" {
+    bashio::api.supervisor() { store_listing; }
+    run bashio::addons.installed
+    [ "${status}" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
+    [ "${lines[0]}" = "alpha" ]
+}
+
+@test "addon.installed reports true for an installed addon" {
+    bashio::api.supervisor() {
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"alpha","installed":true}'
+        fi
+    }
+    run bashio::addon.installed "alpha"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "addon.installed reports true when installed is null (addons API)" {
+    # When info comes from the addons API the installed field is null, which the
+    # filter coalesces to true.
+    bashio::api.supervisor() {
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"alpha","installed":null}'
+        fi
+    }
+    run bashio::addon.installed "alpha"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "addon.slug returns the slug of self" {
+    bashio::api.supervisor() {
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' '{"slug":"my_self_slug"}'
+        fi
+    }
+    run bashio::addon.slug
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "my_self_slug" ]
+}
+
+# ------------------------------------------------------------------------------
+# Scalar getters. These all flow through bashio::addons with a fixed filter; a
+# representative set is checked end to end to confirm the filter and value.
+# ------------------------------------------------------------------------------
+
+# Fetches a single addon field for the "alpha" addon using the given JSON body.
+get_field() {
+    local body="$1"
+    shift
+    BODY="${body}"
+    bashio::api.supervisor() {
+        if [[ "$2" == "/store/addons" ]]; then
+            store_listing
+        else
+            printf '%s' "${BODY}"
+        fi
+    }
+    "$@" "alpha"
+}
+
+@test "addon.name returns the name field" {
+    run get_field '{"slug":"alpha","name":"Alpha"}' bashio::addon.name
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "Alpha" ]
+}
+
+@test "addon.hostname returns the hostname field" {
+    run get_field '{"slug":"alpha","hostname":"alpha-host"}' bashio::addon.hostname
+    [ "${output}" = "alpha-host" ]
+}
+
+@test "addon.description returns the description field" {
+    run get_field '{"slug":"alpha","description":"Desc"}' bashio::addon.description
+    [ "${output}" = "Desc" ]
+}
+
+@test "addon.long_description returns the long_description field" {
+    run get_field '{"slug":"alpha","long_description":"Long"}' bashio::addon.long_description
+    [ "${output}" = "Long" ]
+}
+
+@test "addon.url returns the url field" {
+    run get_field '{"slug":"alpha","url":"http://x"}' bashio::addon.url
+    [ "${output}" = "http://x" ]
+}
+
+@test "addon.version returns the version field" {
+    run get_field '{"slug":"alpha","version":"1.2.3"}' bashio::addon.version
+    [ "${output}" = "1.2.3" ]
+}
+
+@test "addon.version_latest returns the version_latest field" {
+    run get_field '{"slug":"alpha","version_latest":"2.0.0"}' bashio::addon.version_latest
+    [ "${output}" = "2.0.0" ]
+}
+
+@test "addon.state returns the state field" {
+    run get_field '{"slug":"alpha","state":"started"}' bashio::addon.state
+    [ "${output}" = "started" ]
+}
+
+@test "addon.stage returns the stage field" {
+    run get_field '{"slug":"alpha","stage":"stable"}' bashio::addon.stage
+    [ "${output}" = "stable" ]
+}
+
+@test "addon.startup returns the startup field" {
+    run get_field '{"slug":"alpha","startup":"application"}' bashio::addon.startup
+    [ "${output}" = "application" ]
+}
+
+@test "addon.repository returns the repository field" {
+    run get_field '{"slug":"alpha","repository":"core"}' bashio::addon.repository
+    [ "${output}" = "core" ]
+}
+
+@test "addon.apparmor returns the apparmor field" {
+    run get_field '{"slug":"alpha","apparmor":"default"}' bashio::addon.apparmor
+    [ "${output}" = "default" ]
+}
+
+@test "addon.hassio_role returns the role field" { # codespell:ignore hassio
+    run get_field '{"slug":"alpha","hassio_role":"manager"}' bashio::addon.hassio_role
+    [ "${output}" = "manager" ]
+}
+
+@test "addon.homeassistant returns the minimal core version" {
+    run get_field '{"slug":"alpha","homeassistant":"2024.1.0"}' bashio::addon.homeassistant
+    [ "${output}" = "2024.1.0" ]
+}
+
+@test "addon.rating returns the rating field" {
+    run get_field '{"slug":"alpha","rating":6}' bashio::addon.rating
+    [ "${output}" = "6" ]
+}
+
+# ------------------------------------------------------------------------------
+# Boolean getters with `// false` defaults: check both the explicit value and
+# the fallback when the field is absent.
+# ------------------------------------------------------------------------------
+
+@test "addon.detached returns the detached value" {
+    run get_field '{"slug":"alpha","detached":true}' bashio::addon.detached
+    [ "${output}" = "true" ]
+}
+
+@test "addon.detached defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.detached
+    [ "${output}" = "false" ]
+}
+
+@test "addon.available returns the available value" {
+    run get_field '{"slug":"alpha","available":true}' bashio::addon.available
+    [ "${output}" = "true" ]
+}
+
+@test "addon.advanced defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.advanced
+    [ "${output}" = "false" ]
+}
+
+@test "addon.update_available returns the value" {
+    run get_field '{"slug":"alpha","update_available":true}' bashio::addon.update_available
+    [ "${output}" = "true" ]
+}
+
+@test "addon.build defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.build
+    [ "${output}" = "false" ]
+}
+
+@test "addon.host_network returns the value" {
+    run get_field '{"slug":"alpha","host_network":true}' bashio::addon.host_network
+    [ "${output}" = "true" ]
+}
+
+@test "addon.host_pid defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.host_pid
+    [ "${output}" = "false" ]
+}
+
+@test "addon.host_ipc returns the value" {
+    run get_field '{"slug":"alpha","host_ipc":true}' bashio::addon.host_ipc
+    [ "${output}" = "true" ]
+}
+
+@test "addon.host_dbus defaults to false when absent" { # codespell:ignore dbus
+    run get_field '{"slug":"alpha"}' bashio::addon.host_dbus
+    [ "${output}" = "false" ]
+}
+
+@test "addon.udev returns the value" {
+    run get_field '{"slug":"alpha","udev":true}' bashio::addon.udev
+    [ "${output}" = "true" ]
+}
+
+@test "addon.uart defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.uart
+    [ "${output}" = "false" ]
+}
+
+@test "addon.usb returns the value" {
+    run get_field '{"slug":"alpha","usb":true}' bashio::addon.usb
+    [ "${output}" = "true" ]
+}
+
+@test "addon.icon defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.icon
+    [ "${output}" = "false" ]
+}
+
+@test "addon.logo returns the value" {
+    run get_field '{"slug":"alpha","logo":true}' bashio::addon.logo
+    [ "${output}" = "true" ]
+}
+
+@test "addon.has_documentation defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.has_documentation
+    [ "${output}" = "false" ]
+}
+
+@test "addon.has_changelog returns the value" {
+    run get_field '{"slug":"alpha","changelog":true}' bashio::addon.has_changelog
+    [ "${output}" = "true" ]
+}
+
+@test "addon.hassio_api defaults to false when absent" { # codespell:ignore hassio
+    run get_field '{"slug":"alpha"}' bashio::addon.hassio_api
+    [ "${output}" = "false" ]
+}
+
+@test "addon.homeassistant_api returns the value" {
+    run get_field '{"slug":"alpha","homeassistant_api":true}' bashio::addon.homeassistant_api
+    [ "${output}" = "true" ]
+}
+
+@test "addon.auth_api defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.auth_api
+    [ "${output}" = "false" ]
+}
+
+@test "addon.protected returns the value" {
+    run get_field '{"slug":"alpha","protected":true}' bashio::addon.protected
+    [ "${output}" = "true" ]
+}
+
+@test "addon.stdin defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.stdin
+    [ "${output}" = "false" ]
+}
+
+@test "addon.full_access returns the value" {
+    run get_field '{"slug":"alpha","full_access":true}' bashio::addon.full_access
+    [ "${output}" = "true" ]
+}
+
+@test "addon.gpio defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.gpio
+    [ "${output}" = "false" ]
+}
+
+@test "addon.kernel_modules returns the value" {
+    run get_field '{"slug":"alpha","kernel_modules":true}' bashio::addon.kernel_modules
+    [ "${output}" = "true" ]
+}
+
+@test "addon.devicetree defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.devicetree
+    [ "${output}" = "false" ]
+}
+
+@test "addon.docker_api returns the value" {
+    run get_field '{"slug":"alpha","docker_api":true}' bashio::addon.docker_api
+    [ "${output}" = "true" ]
+}
+
+@test "addon.video defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.video
+    [ "${output}" = "false" ]
+}
+
+@test "addon.audio returns the value" {
+    run get_field '{"slug":"alpha","audio":true}' bashio::addon.audio
+    [ "${output}" = "true" ]
+}
+
+@test "addon.ingress defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.ingress
+    [ "${output}" = "false" ]
+}
+
+# ------------------------------------------------------------------------------
+# Getters with `// empty` defaults: absent fields produce empty output.
+# ------------------------------------------------------------------------------
+
+@test "addon.webui returns the value" {
+    run get_field '{"slug":"alpha","webui":"http://[HOST]"}' bashio::addon.webui
+    [ "${output}" = "http://[HOST]" ]
+}
+
+@test "addon.webui is empty when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.webui
+    [ "${output}" = "" ]
+}
+
+@test "addon.ip_address returns the value" {
+    run get_field '{"slug":"alpha","ip_address":"172.30.0.2"}' bashio::addon.ip_address
+    [ "${output}" = "172.30.0.2" ]
+}
+
+@test "addon.ip_address is empty when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.ip_address
+    [ "${output}" = "" ]
+}
+
+@test "addon.ingress_entry returns the value" {
+    run get_field '{"slug":"alpha","ingress_entry":"/api/ingress/x"}' bashio::addon.ingress_entry
+    [ "${output}" = "/api/ingress/x" ]
+}
+
+@test "addon.ingress_url returns the value" {
+    run get_field '{"slug":"alpha","ingress_url":"/x/"}' bashio::addon.ingress_url
+    [ "${output}" = "/x/" ]
+}
+
+@test "addon.ingress_port returns the value" {
+    run get_field '{"slug":"alpha","ingress_port":8099}' bashio::addon.ingress_port
+    [ "${output}" = "8099" ]
+}
+
+@test "addon.ingress_port is empty when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.ingress_port
+    [ "${output}" = "" ]
+}
+
+@test "addon.network_description is empty when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.network_description
+    [ "${output}" = "" ]
+}
+
+# ------------------------------------------------------------------------------
+# List getters: arrays expanded one element per line.
+# ------------------------------------------------------------------------------
+
+@test "addon.dns lists each DNS name" {
+    run get_field '{"slug":"alpha","dns":["dns1","dns2"]}' bashio::addon.dns
+    [ "${status}" -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "dns1" ]
+    [ "${lines[1]}" = "dns2" ]
+}
+
+@test "addon.dns is empty when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.dns
+    [ "${output}" = "" ]
+}
+
+@test "addon.arch lists each architecture" {
+    run get_field '{"slug":"alpha","arch":["amd64","aarch64"]}' bashio::addon.arch
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "amd64" ]
+    [ "${lines[1]}" = "aarch64" ]
+}
+
+@test "addon.machine lists each machine type" {
+    run get_field '{"slug":"alpha","machine":["raspberrypi","tinker"]}' bashio::addon.machine
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "raspberrypi" ]
+    [ "${lines[1]}" = "tinker" ]
+}
+
+@test "addon.privileged lists each privilege" {
+    run get_field '{"slug":"alpha","privileged":["NET_ADMIN","SYS_TIME"]}' bashio::addon.privileged
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "NET_ADMIN" ]
+    [ "${lines[1]}" = "SYS_TIME" ]
+}
+
+@test "addon.devices lists each device" {
+    run get_field '{"slug":"alpha","devices":["/dev/ttyUSB0","/dev/ttyUSB1"]}' bashio::addon.devices
+    [ "${#lines[@]}" -eq 2 ]
+    [ "${lines[0]}" = "/dev/ttyUSB0" ]
+    [ "${lines[1]}" = "/dev/ttyUSB1" ]
+}
+
+@test "addon.devices is empty when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.devices
+    [ "${output}" = "" ]
+}
+
+# ------------------------------------------------------------------------------
+# Setter/getter helpers that POST options. For setters we assert the exact JSON
+# body, and that a failing API call propagates.
+# ------------------------------------------------------------------------------
+
+@test "addon.auto_update reads the value when no second argument is given" {
+    run get_field '{"slug":"alpha","auto_update":true}' bashio::addon.auto_update
+    [ "${output}" = "true" ]
+}
+
+@test "addon.auto_update defaults to false when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.auto_update
+    [ "${output}" = "false" ]
+}
+
+@test "addon.auto_update posts the value as a raw boolean" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.auto_update "alpha" "true"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"auto_update":true}' ]
+}
+
+@test "addon.auto_update propagates an API failure on set" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.auto_update "alpha" "true" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.boot reads the value when no second argument is given" {
+    run get_field '{"slug":"alpha","boot":"auto"}' bashio::addon.boot
+    [ "${output}" = "auto" ]
+}
+
+@test "addon.boot posts the value as a JSON string" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.boot "alpha" "manual"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"boot":"manual"}' ]
+}
+
+@test "addon.boot propagates an API failure on set" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.boot "alpha" "manual" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.ingress_panel reads the value when no second argument is given" {
+    run get_field '{"slug":"alpha","ingress_panel":true}' bashio::addon.ingress_panel
+    [ "${output}" = "true" ]
+}
+
+@test "addon.ingress_panel posts the value as a raw boolean" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.ingress_panel "alpha" "true"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"ingress_panel":true}' ]
+}
+
+@test "addon.watchdog reads the value when no second argument is given" {
+    run get_field '{"slug":"alpha","watchdog":true}' bashio::addon.watchdog
+    [ "${output}" = "true" ]
+}
+
+@test "addon.watchdog posts the value as a raw boolean" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.watchdog "alpha" "false"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"watchdog":false}' ]
+}
+
+@test "addon.watchdog propagates an API failure on set" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.watchdog "alpha" "true" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.audio_input reads the value when no second argument is given" {
+    run get_field '{"slug":"alpha","audio_input":"hw:1,0"}' bashio::addon.audio_input
+    [ "${output}" = "hw:1,0" ]
+}
+
+@test "addon.audio_input is empty when absent" {
+    run get_field '{"slug":"alpha"}' bashio::addon.audio_input
+    [ "${output}" = "" ]
+}
+
+@test "addon.audio_input posts the value as a JSON string" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.audio_input "alpha" "hw:1,0"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"audio_input":"hw:1,0"}' ]
+}
+
+@test "addon.audio_output posts the value as a JSON string" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.audio_output "alpha" "hw:0,0"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"audio_output":"hw:0,0"}' ]
+}
+
+@test "addon.audio_output propagates an API failure on set" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.audio_output "alpha" "hw:0,0" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# addon.options: read mode and write mode.
+# ------------------------------------------------------------------------------
+
+@test "addon.options reads the options object" {
+    run get_field '{"slug":"alpha","options":{"foo":"bar"}}' bashio::addon.options
+    [ "${status}" -eq 0 ]
+    run jq -r '.foo' <<<"${output}"
+    [ "${output}" = "bar" ]
+}
+
+@test "addon.options posts the given options as a raw JSON body" {
+    # The second positional argument is wrapped under the options key as raw
+    # JSON via the ^ prefix internally.
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.options "alpha" '{"foo":"bar"}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"options":{"foo":"bar"}}' ]
+}
+
+@test "addon.options propagates an API failure on set" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.options "alpha" '{}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# addon.option: setting and clearing a single key. These pin the JSON-injection
+# safety contract and the raw "^" prefix behaviour.
+# ------------------------------------------------------------------------------
 
 @test "addon.option stores the value as a literal string (no JSON injection)" {
     bashio::addon.options() {
@@ -50,4 +893,340 @@ setup() {
     bashio::addon.option "enabled" "^true"
     run jq -e '.enabled == true' <"${BATS_TEST_TMPDIR}/opts"
     [ "${status}" -eq 0 ]
+}
+
+@test "addon.option updates an already existing key in place" {
+    bashio::addon.options() {
+        if [[ $# -le 1 ]]; then
+            printf '%s' '{"name":"old"}'
+        else
+            printf '%s' "$2" >"${BATS_TEST_TMPDIR}/opts"
+        fi
+    }
+    bashio::addon.option "name" "new"
+    [ "$(jq -r '.name' <"${BATS_TEST_TMPDIR}/opts")" = "new" ]
+}
+
+@test "addon.option removes a key when no value is given" {
+    bashio::addon.options() {
+        if [[ $# -le 1 ]]; then
+            printf '%s' '{"keep":"yes","drop":"no"}'
+        else
+            printf '%s' "$2" >"${BATS_TEST_TMPDIR}/opts"
+        fi
+    }
+    bashio::addon.option "drop"
+    # The dropped key is gone...
+    run jq -e 'has("drop")' <"${BATS_TEST_TMPDIR}/opts"
+    [ "${status}" -ne 0 ]
+    # ...while the other key is untouched.
+    [ "$(jq -r '.keep' <"${BATS_TEST_TMPDIR}/opts")" = "yes" ]
+}
+
+@test "addon.option sets a raw JSON object with the ^ prefix" {
+    bashio::addon.options() {
+        if [[ $# -le 1 ]]; then
+            printf '%s' '{}'
+        else
+            printf '%s' "$2" >"${BATS_TEST_TMPDIR}/opts"
+        fi
+    }
+    bashio::addon.option "nested" '^{"a":1}'
+    run jq -e '.nested.a == 1' <"${BATS_TEST_TMPDIR}/opts"
+    [ "${status}" -eq 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# addon.config: self-only config with caching and the empty -> {} fallback.
+# ------------------------------------------------------------------------------
+
+@test "addon.config requests the self options config" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"foo":"bar"}'
+    }
+    run bashio::addon.config
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /addons/self/options/config false" ]
+    run jq -r '.foo' <<<"${output}"
+    [ "${output}" = "bar" ]
+}
+
+@test "addon.config turns an empty response into an empty JSON object" {
+    bashio::api.supervisor() { printf '%s' ''; }
+    run bashio::addon.config
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "{}" ]
+}
+
+@test "addon.config serves from cache without calling the API" {
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    printf '%s' '{"cached":true}' >"${__BASHIO_CACHE_DIR}/addons.self.options.config.cache"
+    bashio::api.supervisor() {
+        echo "API SHOULD NOT BE CALLED"
+        return 1
+    }
+    run bashio::addon.config
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"cached":true}' ]
+}
+
+@test "addon.config fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.config >/dev/null || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# Network and port helpers.
+# ------------------------------------------------------------------------------
+
+@test "addon.network returns the network map when present" {
+    run get_field '{"slug":"alpha","network":{"80/tcp":8080}}' bashio::addon.network
+    [ "${status}" -eq 0 ]
+    run jq -r '."80/tcp"' <<<"${output}"
+    [ "${output}" = "8080" ]
+}
+
+@test "addon.network is empty when the network map is an empty object" {
+    run get_field '{"slug":"alpha","network":{}}' bashio::addon.network
+    [ "${output}" = "" ]
+}
+
+@test "addon.network posts the given network map as a raw JSON body" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::addon.network "alpha" '{"80/tcp":8080}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"network":{"80/tcp":8080}}' ]
+}
+
+@test "addon.network propagates an API failure on set" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.network "alpha" '{}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.network_description returns the descriptions when present" {
+    run get_field '{"slug":"alpha","network_description":{"80/tcp":"Web"}}' bashio::addon.network_description
+    run jq -r '."80/tcp"' <<<"${output}"
+    [ "${output}" = "Web" ]
+}
+
+@test "addon.port reads the mapped port, defaulting the protocol to tcp" {
+    run get_field '{"slug":"alpha","network":{"80/tcp":8080}}' bashio::addon.port "80"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "8080" ]
+}
+
+@test "addon.port reads a port with an explicit protocol" {
+    run get_field '{"slug":"alpha","network":{"53/udp":5353}}' bashio::addon.port "53/udp"
+    [ "${output}" = "5353" ]
+}
+
+@test "addon.port is empty when the port is not mapped" {
+    run get_field '{"slug":"alpha","network":{}}' bashio::addon.port "80"
+    [ "${output}" = "" ]
+}
+
+@test "addon.port sets a user port by merging into the network map" {
+    # Read returns the current network, write records the merged result. The
+    # third argument switches the function into set mode.
+    bashio::addon.network() {
+        if [[ $# -ge 2 ]]; then
+            echo "$2" >"${BATS_TEST_TMPDIR}/net"
+        else
+            printf '%s' '{"80/tcp":8080}'
+        fi
+    }
+    run bashio::addon.port "443" "alpha" "8443"
+    [ "${status}" -eq 0 ]
+    [ "$(jq -r '."443/tcp"' <"${BATS_TEST_TMPDIR}/net")" = "8443" ]
+    # The pre-existing mapping is preserved.
+    [ "$(jq -r '."80/tcp"' <"${BATS_TEST_TMPDIR}/net")" = "8080" ]
+}
+
+@test "addon.port_description reads the description, defaulting to tcp" {
+    run get_field '{"slug":"alpha","network_description":{"80/tcp":"Web UI"}}' bashio::addon.port_description "80"
+    [ "${output}" = "Web UI" ]
+}
+
+# ------------------------------------------------------------------------------
+# Stats fetcher and its derived getters.
+# ------------------------------------------------------------------------------
+
+# Stubs the API so the stats endpoint returns the given body.
+stats_field() {
+    local body="$1"
+    shift
+    BODY="${body}"
+    bashio::api.supervisor() {
+        echo "$*" >>"${BATS_TEST_TMPDIR}/calls"
+        printf '%s' "${BODY}"
+    }
+    "$@" "alpha"
+}
+
+@test "addon.stats fetches the stats endpoint and returns the raw object" {
+    run stats_field '{"cpu_percent":1.5,"memory_usage":100}' bashio::addon.stats
+    [ "${status}" -eq 0 ]
+    run cat "${BATS_TEST_TMPDIR}/calls"
+    [ "${lines[0]}" = "GET /addons/alpha/stats false" ]
+}
+
+@test "addon.stats fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.stats "alpha" >/dev/null || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.stats serves from its cache key without calling the API" {
+    mkdir -p "${__BASHIO_CACHE_DIR}"
+    printf '%s' '{"cpu_percent":9}' >"${__BASHIO_CACHE_DIR}/addons.alpha.stats.cache"
+    bashio::api.supervisor() {
+        echo "API SHOULD NOT BE CALLED"
+        return 1
+    }
+    run bashio::addon.stats "alpha"
+    [ "${status}" -eq 0 ]
+    run jq -r '.cpu_percent' <<<"${output}"
+    [ "${output}" = "9" ]
+}
+
+# The derived stat getters (cpu_percent, memory_usage, memory_limit,
+# memory_percent, network_tx, network_rx, blk_read, blk_write) all dispatch to
+# bashio::addon.stats with a per-field jq filter and return the extracted value.
+
+@test "addon.cpu_percent returns the cpu_percent value from the stats" {
+    run stats_field '{"cpu_percent":1.5}' bashio::addon.cpu_percent
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1.5" ]
+}
+
+@test "addon.cpu_percent fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.cpu_percent "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.memory_usage returns the memory_usage value from the stats" {
+    run stats_field '{"memory_usage":2048}' bashio::addon.memory_usage
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2048" ]
+}
+
+@test "addon.memory_usage fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.memory_usage "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.memory_limit returns the memory_limit value from the stats" {
+    run stats_field '{"memory_limit":4096}' bashio::addon.memory_limit
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "4096" ]
+}
+
+@test "addon.memory_limit fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.memory_limit "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.memory_percent returns the memory_percent value from the stats" {
+    run stats_field '{"memory_percent":50.0}' bashio::addon.memory_percent
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "50.0" ]
+}
+
+@test "addon.memory_percent fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.memory_percent "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.network_tx returns the network_tx value from the stats" {
+    run stats_field '{"network_tx":1000}' bashio::addon.network_tx
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1000" ]
+}
+
+@test "addon.network_tx fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.network_tx "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.network_rx returns the network_rx value from the stats" {
+    run stats_field '{"network_rx":2000}' bashio::addon.network_rx
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "2000" ]
+}
+
+@test "addon.network_rx fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.network_rx "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.blk_read returns the blk_read value from the stats" {
+    run stats_field '{"blk_read":300}' bashio::addon.blk_read
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "300" ]
+}
+
+@test "addon.blk_read fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.blk_read "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "addon.blk_write returns the blk_write value from the stats" {
+    run stats_field '{"blk_write":400}' bashio::addon.blk_write
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "400" ]
+}
+
+@test "addon.blk_write fails when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::addon.blk_write "alpha" >/dev/null 2>&1 || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# Protection-mode guards.
+# ------------------------------------------------------------------------------
+
+@test "require.protected succeeds when protection mode is enabled" {
+    bashio::addon.protected() { printf '%s' "true"; }
+    run bashio::require.protected
+    [ "${status}" -eq 0 ]
+}
+
+@test "require.protected exits non-zero when protection mode is disabled" {
+    bashio::addon.protected() { printf '%s' "false"; }
+    run bashio::require.protected
+    [ "${status}" -ne 0 ]
+}
+
+@test "require.unprotected succeeds when protection mode is disabled" {
+    bashio::addon.protected() { printf '%s' "false"; }
+    run bashio::require.unprotected
+    [ "${status}" -eq 0 ]
+}
+
+@test "require.unprotected exits non-zero when protection mode is enabled" {
+    bashio::addon.protected() { printf '%s' "true"; }
+    run bashio::require.unprotected
+    [ "${status}" -ne 0 ]
 }


### PR DESCRIPTION
# Proposed Changes

Wave 2 of the per-module coverage work: expand `lib/addons.sh` to 158
tests (from 3), covering every function with meaningful cases, not
happy-path only. The Supervisor API boundary is stubbed and the exact
forwarded method/endpoint/filter is asserted, getters and setters are
tested in both directions, list output is asserted line by line,
`addon.option` covers the string (no JSON injection), raw `^`-JSON, and
key-removal paths, and error/failure propagation is covered.

This coverage uncovered a real library bug, fixed here: the eight
derived stat getters (`addon.cpu_percent`, `memory_usage`,
`memory_limit`, `memory_percent`, `network_tx`, `network_rx`,
`blk_read`, `blk_write`) dispatched to the non-existent
`bashio::addons.stats` (plural) instead of `bashio::addon.stats`
(singular, defined in the same file), so each failed with
command-not-found before reading any value. The eight call sites are
corrected and the getters now return their values.

The lib fix is bundled here because the tests that exercise these
getters depend on it (otherwise they would assert broken behaviour). It
is a one-token change at eight call sites; happy to split it into its
own PR if preferred.

## Related Issues

>
