### PR TITLE
Propagate API failures from cache-flushing action helpers

### DIFF
--- a/lib/backups.sh
+++ b/lib/backups.sh
@@ -376,7 +376,8 @@ function bashio::backup.new_partial() {
 function bashio::backup.delete() {
     local slug=${1}
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::api.supervisor DELETE "/backups/${slug}"
+    bashio::api.supervisor DELETE "/backups/${slug}" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }
 

--- a/lib/discovery.sh
+++ b/lib/discovery.sh
@@ -27,7 +27,8 @@ function bashio::discovery() {
             config "^${config}"
     )
 
-    bashio::api.supervisor "POST" "/discovery" "${payload}" ".uuid"
+    bashio::api.supervisor "POST" "/discovery" "${payload}" ".uuid" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }
 
@@ -41,6 +42,7 @@ function bashio::discovery.delete() {
     local uuid=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::api.supervisor "DELETE" "/discovery/${uuid}"
+    bashio::api.supervisor "DELETE" "/discovery/${uuid}" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }

--- a/lib/jobs.sh
+++ b/lib/jobs.sh
@@ -201,6 +201,7 @@ function bashio::job.delete() {
     local uuid=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::api.supervisor "DELETE" "/jobs/${uuid}"
+    bashio::api.supervisor "DELETE" "/jobs/${uuid}" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }

--- a/lib/repositories.sh
+++ b/lib/repositories.sh
@@ -159,7 +159,8 @@ function bashio::repository.delete() {
     local slug=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::api.supervisor "DELETE" "/store/repositories/${slug}"
+    bashio::api.supervisor "DELETE" "/store/repositories/${slug}" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }
 
@@ -173,6 +174,7 @@ function bashio::repository.repair() {
     local slug=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::api.supervisor "POST" "/store/repositories/${slug}/repair"
+    bashio::api.supervisor "POST" "/store/repositories/${slug}/repair" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }

--- a/lib/services.sh
+++ b/lib/services.sh
@@ -100,7 +100,8 @@ function bashio::services.publish() {
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
-    bashio::api.supervisor "POST" "/services/${service}" "${config}"
+    bashio::api.supervisor "POST" "/services/${service}" "${config}" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }
 
@@ -114,6 +115,7 @@ function bashio::services.delete() {
     local service=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
-    bashio::api.supervisor "DELETE" "/services/${service}"
+    bashio::api.supervisor "DELETE" "/services/${service}" ||
+        return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }

--- a/tests/backups.bats
+++ b/tests/backups.bats
@@ -407,6 +407,13 @@ setup() {
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /backups/aaa" ]
 }
 
+@test "backup.delete propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::backup.delete "aaa" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
 # ------------------------------------------------------------------------------
 # backup.restore_full / backup.restore_partial
 # ------------------------------------------------------------------------------

--- a/tests/discovery.bats
+++ b/tests/discovery.bats
@@ -77,14 +77,13 @@ setup() {
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
 
-@test "discovery masks API failure: cache is flushed and exit status is 0" {
-    # bashio::discovery does not propagate the API return code: its return
-    # status is whatever bashio::cache.flush_all returns. An API failure is
-    # only masked when the caller suppresses errexit (as here, with `|| rc=$?`).
-    # Prime a cache entry to confirm the flush still runs even when the API
-    # call fails, and record the call so we can prove the API was attempted.
+@test "discovery propagates an API failure" {
+    # The failing Supervisor call is attempted and its failure is returned to
+    # the caller (captured with `|| rc=$?` since errexit is suppressed in a
+    # conditional context). The function returns before flushing, so a primed
+    # cache entry survives.
     bashio::cache.set "some.key" "before-failure"
-    [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
+    [ -f "${__BASHIO_CACHE_DIR}/some.key.cache" ]
 
     bashio::api.supervisor() {
         printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
@@ -92,12 +91,11 @@ setup() {
     }
     rc=0
     bashio::discovery "mqtt" '{"host":"x"}' >/dev/null || rc=$?
-    [ "${rc}" -eq 0 ]
+    [ "${rc}" -ne 0 ]
     # The failing Supervisor call must still have been attempted.
     call="$(cat "${BATS_TEST_TMPDIR}/call")"
     [[ "${call}" == "POST /discovery "* ]]
-    # The cache must be gone, proving flush_all ran despite the API failure.
-    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+    [ -f "${__BASHIO_CACHE_DIR}/some.key.cache" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -130,14 +128,13 @@ setup() {
     [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
 }
 
-@test "discovery.delete masks API failure: cache is flushed and exit status is 0" {
-    # bashio::discovery.delete does not propagate the API return code: its
-    # return status is whatever bashio::cache.flush_all returns. An API failure
-    # is only masked when the caller suppresses errexit (as here, with
-    # `|| rc=$?`). Prime a cache entry to confirm the flush still runs even when
-    # the API call fails, and record the call so we can prove it was attempted.
+@test "discovery.delete propagates an API failure" {
+    # The failing Supervisor call is attempted and its failure is returned to
+    # the caller (captured with `|| rc=$?` since errexit is suppressed in a
+    # conditional context). The function returns before flushing, so a primed
+    # cache entry survives.
     bashio::cache.set "some.key" "before-failure"
-    [ -f "${BATS_TEST_TMPDIR}/cache/some.key.cache" ]
+    [ -f "${__BASHIO_CACHE_DIR}/some.key.cache" ]
 
     bashio::api.supervisor() {
         printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
@@ -145,10 +142,9 @@ setup() {
     }
     rc=0
     bashio::discovery.delete "abc-def-uuid" || rc=$?
-    [ "${rc}" -eq 0 ]
+    [ "${rc}" -ne 0 ]
     # The failing Supervisor call must still have been attempted.
     call="$(cat "${BATS_TEST_TMPDIR}/call")"
     [ "${call}" = "DELETE /discovery/abc-def-uuid" ]
-    # The cache must be gone, proving flush_all ran despite the API failure.
-    [ ! -d "${BATS_TEST_TMPDIR}/cache" ]
+    [ -f "${__BASHIO_CACHE_DIR}/some.key.cache" ]
 }

--- a/tests/jobs.bats
+++ b/tests/jobs.bats
@@ -253,3 +253,10 @@ setup() {
     [ "${status}" -eq 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /jobs/111" ]
 }
+
+@test "job.delete propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::job.delete "111" || rc=$?
+    [ "${rc}" -ne 0 ]
+}

--- a/tests/repositories.bats
+++ b/tests/repositories.bats
@@ -253,6 +253,13 @@ setup() {
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /store/repositories/core" ]
 }
 
+@test "repository.delete propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::repository.delete "core" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
 # ------------------------------------------------------------------------------
 # bashio::repository.repair
 # ------------------------------------------------------------------------------
@@ -262,4 +269,11 @@ setup() {
     run bashio::repository.repair "core"
     [ "${status}" -eq 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /store/repositories/core/repair" ]
+}
+
+@test "repository.repair propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::repository.repair "core" || rc=$?
+    [ "${rc}" -ne 0 ]
 }

--- a/tests/services.bats
+++ b/tests/services.bats
@@ -190,21 +190,21 @@ setup() {
     [ ! -d "${__BASHIO_CACHE_DIR}" ]
 }
 
-@test "services.publish flushes the cache even when the API call fails" {
-    # bashio::services.publish does not check the API return code; it calls
-    # bashio::cache.flush_all after the API call regardless of its outcome.
-    # When errexit is suppressed (as it is under `run`), the failing API call
-    # does not abort the function, so the flush is still observed.
-    # Prime the cache first.
+@test "services.publish propagates an API failure" {
+    # The failing API call is attempted and its failure is returned to the
+    # caller; the function returns before flushing, so the cache is untouched.
     bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
     bashio::services "mqtt" >/dev/null
     [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
 
-    # Now publish with a failing API stub; the cache must still be flushed.
-    bashio::api.supervisor() { return 1; }
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
     run bashio::services.publish "mqtt" '{"host":"x"}'
-    [ ! -e "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
-    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /services/mqtt {"host":"x"}' ]
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -231,19 +231,19 @@ setup() {
     [ ! -d "${__BASHIO_CACHE_DIR}" ]
 }
 
-@test "services.delete flushes the cache even when the API call fails" {
-    # bashio::services.delete does not check the API return code; it calls
-    # bashio::cache.flush_all after the API call regardless of its outcome.
-    # When errexit is suppressed (as it is under `run`), the failing API call
-    # does not abort the function, so the flush is still observed.
-    # Prime the cache first.
+@test "services.delete propagates an API failure" {
+    # The failing API call is attempted and its failure is returned to the
+    # caller; the function returns before flushing, so the cache is untouched.
     bashio::api.supervisor() { printf '%s' "${SERVICE_JSON}"; }
     bashio::services "mqtt" >/dev/null
     [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
 
-    # Now delete with a failing API stub; the cache must still be flushed.
-    bashio::api.supervisor() { return 1; }
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
     run bashio::services.delete "mqtt"
-    [ ! -e "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
-    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /services/mqtt" ]
+    [ -f "${__BASHIO_CACHE_DIR}/service.info.mqtt.cache" ]
 }


### PR DESCRIPTION
# Proposed Changes

Eight action helpers contacted the Supervisor API and then flushed the
cache without checking the API result, so a failed request was silently
swallowed (the function returned `bashio::cache.flush_all`'s status,
effectively reporting success): `services.publish`, `services.delete`,
`discovery`, `discovery.delete`, `repository.delete`,
`repository.repair`, `backup.delete`, `job.delete`.

Each now uses the same `|| return "${__BASHIO_EXIT_NOK}"` guard the
other action helpers already use (for example `backups.reload`,
`addon.update`), so an API failure is returned to the caller. As a
consequence the cache is no longer flushed when the call fails (the
function returns first), matching the established idiom.

These were surfaced by the per-module test coverage: the affected tests
had documented the old masking behaviour. They are updated to assert
propagation, and failure-propagation tests are added for the
repository/backup/job helpers (which previously could not be tested for
it). Verified test-first: the updated assertions fail against the
pre-fix library and pass with it.

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for backup, discovery, job, repository, and service operations. These operations now properly propagate API failures instead of silently continuing on error.

* **Tests**
  * Added and updated test coverage to validate error propagation behavior across all affected operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->