### PR TITLE
Cover untested error branches and functions

### DIFF
--- a/tests/api.bats
+++ b/tests/api.bats
@@ -41,10 +41,46 @@ setup() {
     [ "${status}" -ne 0 ]
 }
 
+@test "api.supervisor fails on a forbidden error (403)" {
+    MOCK_BODY='{"result":"error","message":"forbidden"}'
+    MOCK_STATUS='403'
+    run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}
+
 @test "api.supervisor fails on a not-found error (404)" {
     MOCK_BODY='{"result":"error","message":"missing"}'
     MOCK_STATUS='404'
     run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}
+
+@test "api.supervisor fails on a method-not-allowed error (405)" {
+    MOCK_BODY='{"result":"error","message":"nope"}'
+    MOCK_STATUS='405'
+    run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}
+
+@test "api.supervisor fails on an unexpected HTTP status with no error result" {
+    # A non-200 status whose body does not carry a "result":"error" must still
+    # be reported as a failure by the catch-all status check.
+    MOCK_BODY='{"result":"ok"}'
+    MOCK_STATUS='500'
+    run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}
+
+@test "api.supervisor fails when the request to curl itself fails" {
+    curl() { return 1; }
+    run bashio::api.supervisor GET /test
+    [ "${status}" -ne 0 ]
+}
+
+@test "api.supervisor fails when the jq filter is invalid" {
+    MOCK_BODY='{"result":"ok","data":{"hello":"world"}}'
+    MOCK_STATUS='200'
+    run bashio::api.supervisor GET /test false '.['
     [ "${status}" -ne 0 ]
 }
 

--- a/tests/fs.bats
+++ b/tests/fs.bats
@@ -57,3 +57,13 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     run bashio::fs.socket_exists "${BATS_TEST_TMPDIR}/not-a-socket"
     [ "${status}" -ne 0 ]
 }
+
+@test "fs.socket_exists succeeds for a real socket" {
+    # Create an actual UNIX domain socket. python3 is used because the shell has
+    # no portable way to bind one; skip if it is unavailable.
+    command -v python3 >/dev/null 2>&1 || skip "python3 not available to create a socket"
+    local sock="${BATS_TEST_TMPDIR}/sock"
+    python3 -c "import socket; s = socket.socket(socket.AF_UNIX); s.bind('${sock}')"
+    run bashio::fs.socket_exists "${sock}"
+    [ "${status}" -eq 0 ]
+}

--- a/tests/jq.bats
+++ b/tests/jq.bats
@@ -75,3 +75,17 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     [ "${status}" -eq 0 ]
     [ "$(jq -r '.name' <<<"${output}")" = 'a"b' ]
 }
+
+@test "jq.is_boolean detects a boolean and rejects other types" {
+    run bashio::jq.is_boolean '{"flag":true}' '.flag'
+    [ "${status}" -eq 0 ]
+    run bashio::jq.is_boolean '{"flag":"true"}' '.flag'
+    [ "${status}" -ne 0 ]
+}
+
+@test "jq.is_array detects an array and rejects other types" {
+    run bashio::jq.is_array '{"items":[1,2]}' '.items'
+    [ "${status}" -eq 0 ]
+    run bashio::jq.is_array '{"items":"nope"}' '.items'
+    [ "${status}" -ne 0 ]
+}

--- a/tests/var.bats
+++ b/tests/var.bats
@@ -85,3 +85,31 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     [ "${status}" -eq 0 ]
     [ "${output}" = '"he said \"hi\""' ]
 }
+
+@test "bashio::var.defined succeeds for a set variable and fails for an unset one" {
+    # shellcheck disable=SC2034
+    a_defined_variable="value"
+    run bashio::var.defined "a_defined_variable"
+    [ "${status}" -eq 0 ]
+    run bashio::var.defined "a_variable_that_is_not_set"
+    [ "${status}" -ne 0 ]
+}
+
+@test "bashio::var.defined treats an empty-but-set variable as defined" {
+    # shellcheck disable=SC2034
+    an_empty_variable=""
+    run bashio::var.defined "an_empty_variable"
+    [ "${status}" -eq 0 ]
+}
+
+@test "bashio::var.json_array builds a JSON array from its arguments" {
+    run bashio::var.json_array one two three
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '["one","two","three"]' ]
+}
+
+@test "bashio::var.json_array escapes its elements" {
+    run bashio::var.json_array 'a"b'
+    [ "${status}" -eq 0 ]
+    [ "$(jq -r '.[0]' <<<"${output}")" = 'a"b' ]
+}


### PR DESCRIPTION
# Proposed Changes

Targeted coverage for genuinely untested branches and functions,
identified from the coverage report (distinct from the bashcov
subshell-measurement noise that makes some already-tested functions
flicker as uncovered).

- `api.supervisor`: add the `403`, `405`, and generic non-200 status
  branches, a failed `curl` invocation, and a failing jq filter. Only
  `401`/`404`/error-result were covered before, which is why `api.sh`
  was the lowest real file.
- `fs.socket_exists`: cover the success path against a real UNIX socket
  (created via `python3`, skipped if unavailable). Only the failure path
  existed.
- `jq.is_boolean` and `jq.is_array`: were never referenced by any test.
- `var.defined` (set, unset, and empty-but-set) and `var.json_array`:
  were never referenced by any test.

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for API error handling, including HTTP 403, 405, 500 errors and curl/jq failure scenarios
  * Added tests for socket file system existence verification
  * Added tests for JSON type validation (boolean and array types)
  * Added tests for variable definition checking and JSON array helper functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->