### PR TITLE
Validate cache keys to prevent path traversal

### DIFF
--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -21,12 +21,18 @@
 # ------------------------------------------------------------------------------
 function bashio::cache.__valid_key() {
     local key=${1:-}
+    local display
 
     if [[ "${key}" =~ ^[A-Za-z0-9._-]+$ ]]; then
         return "${__BASHIO_EXIT_OK}"
     fi
 
-    bashio::log.error "Invalid cache key: '${key}'"
+    # Sanitize the rejected (untrusted) key before logging it: strip control
+    # characters and backslashes so it cannot inject newlines or escape
+    # sequences through the log formatter's printf '%b'.
+    display=${key//[[:cntrl:]]/?}
+    display=${display//\\/?}
+    bashio::log.error "Invalid cache key: '${display}'"
     return "${__BASHIO_EXIT_NOK}"
 }
 

--- a/lib/cache.sh
+++ b/lib/cache.sh
@@ -8,6 +8,29 @@
 # ==============================================================================
 
 # ------------------------------------------------------------------------------
+# Checks that a cache key is a safe filename, to prevent path traversal.
+#
+# The key is interpolated into the path "${__BASHIO_CACHE_DIR}/<key>.cache", so
+# it must be a single path component: a slash or other unexpected character
+# could read from or write to a location outside the cache directory. Keys are
+# restricted to letters, digits, dots, underscores and hyphens; every key
+# bashio itself uses fits this.
+#
+# Arguments:
+#   $1 Cache key
+# ------------------------------------------------------------------------------
+function bashio::cache.__valid_key() {
+    local key=${1:-}
+
+    if [[ "${key}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    bashio::log.error "Invalid cache key: '${key}'"
+    return "${__BASHIO_EXIT_NOK}"
+}
+
+# ------------------------------------------------------------------------------
 # Check if a cache key exists in the cache
 #
 # Arguments:
@@ -17,6 +40,8 @@ function bashio::cache.exists() {
     local key=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::cache.__valid_key "${key}" || return "${__BASHIO_EXIT_NOK}"
 
     if bashio::fs.file_exists "${__BASHIO_CACHE_DIR}/${key}.cache"; then
         return "${__BASHIO_EXIT_OK}"
@@ -56,6 +81,8 @@ function bashio::cache.set() {
     local value=${2}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::cache.__valid_key "${key}" || return "${__BASHIO_EXIT_NOK}"
 
     if ! bashio::fs.directory_exists "${__BASHIO_CACHE_DIR}"; then
         # Cached values can contain secrets, so create the directory with an
@@ -100,6 +127,8 @@ function bashio::cache.flush() {
     local key=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::cache.__valid_key "${key}" || return "${__BASHIO_EXIT_NOK}"
 
     if ! rm -f "${__BASHIO_CACHE_DIR}/${key}.cache"; then
         bashio::exit.nok "An error occurred while flushing ${key} from cache"

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -66,3 +66,44 @@ setup() {
     run bashio::cache.get "key"
     [ "${output}" = "value" ]
 }
+
+@test "cache.set rejects a key containing a slash and writes nothing" {
+    run bashio::cache.set "sub/dir" "value"
+    [ "${status}" -ne 0 ]
+    [ ! -e "${__BASHIO_CACHE_DIR}/sub" ]
+}
+
+@test "cache.set rejects a path-traversal key without escaping the cache dir" {
+    run bashio::cache.set "../escaped" "secret"
+    [ "${status}" -ne 0 ]
+    # Nothing must be written outside the cache directory.
+    [ ! -e "${BATS_TEST_TMPDIR}/escaped.cache" ]
+}
+
+@test "cache.exists rejects an invalid key" {
+    run bashio::cache.exists "../escaped"
+    [ "${status}" -ne 0 ]
+}
+
+@test "cache.get rejects an invalid key" {
+    run bashio::cache.get "bad/key"
+    [ "${status}" -ne 0 ]
+}
+
+@test "cache.flush rejects an invalid key" {
+    run bashio::cache.flush "../../etc/passwd"
+    [ "${status}" -ne 0 ]
+}
+
+@test "cache.set rejects an empty key" {
+    run bashio::cache.set "" "value"
+    [ "${status}" -ne 0 ]
+}
+
+@test "cache.set accepts dotted, hyphen and underscore keys" {
+    # The keys bashio itself uses (e.g. addons.<slug>.info, eth0 interfaces).
+    bashio::cache.set "apps.core_ssh-2.info" "value"
+    run bashio::cache.get "apps.core_ssh-2.info"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "value" ]
+}

--- a/tests/cache.bats
+++ b/tests/cache.bats
@@ -71,6 +71,9 @@ setup() {
     run bashio::cache.set "sub/dir" "value"
     [ "${status}" -ne 0 ]
     [ ! -e "${__BASHIO_CACHE_DIR}/sub" ]
+    # The key is rejected before any filesystem access, so the cache directory
+    # is not even created.
+    [ ! -e "${__BASHIO_CACHE_DIR}" ]
 }
 
 @test "cache.set rejects a path-traversal key without escaping the cache dir" {
@@ -90,9 +93,28 @@ setup() {
     [ "${status}" -ne 0 ]
 }
 
-@test "cache.flush rejects an invalid key" {
-    run bashio::cache.flush "../../etc/passwd"
+@test "cache.flush rejects an invalid key without deleting outside the cache dir" {
+    # Sentinel outside the cache dir that a traversal key would target.
+    : >"${BATS_TEST_TMPDIR}/escaped.cache"
+    run bashio::cache.flush "../escaped"
     [ "${status}" -ne 0 ]
+    # The arbitrary path must be untouched.
+    [ -e "${BATS_TEST_TMPDIR}/escaped.cache" ]
+}
+
+@test "cache rejecting a key does not inject control characters into the log" {
+    # The rejected key is untrusted; the log formatter uses printf %b, so a
+    # newline or escape sequence in the key must not reach the log verbatim.
+    # Call directly (not via run) so the stub's captured message survives.
+    logged=""
+    bashio::log.error() { logged="$*"; }
+    rc=0
+    bashio::cache.exists "$(printf 'bad\nESC\x1bINJECT')" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ -n "${logged}" ]
+    # The newline and escape character must not survive into the message.
+    [[ "${logged}" != *$'\n'* ]]
+    [[ "${logged}" != *$'\x1b'* ]]
 }
 
 @test "cache.set rejects an empty key" {


### PR DESCRIPTION
# Proposed Changes

Cache keys are interpolated into `${__BASHIO_CACHE_DIR}/<key>.cache`, but
nothing validated them, so a key containing a slash or `..` could escape
the cache directory. For example `bashio::cache.set "../escaped" "x"`
wrote a file in the parent of the cache directory, and
`bashio::cache.flush "../../etc/passwd"` would target an arbitrary path.

This restricts cache keys to a safe single-component filename charset
(`[A-Za-z0-9._-]`) via a small helper used by `cache.exists`,
`cache.set`, and `cache.flush` (`cache.get` is covered because it goes
through `cache.exists`). Every cache key bashio itself uses (for example
`apps.<slug>.info`, `supervisor.info.<field>`, interface names) already
fits this; an invalid key is now rejected and the filesystem is left
untouched.

This closes the last item from the security review (the `var.json` /
cache hardening follow-ups). Verified test-first: the path-traversal,
arbitrary-flush, and empty-key cases fail against the previous code and
pass with the validation.

## Related Issues

>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cache operations now validate keys to prevent invalid characters and path traversal attempts, rejecting non-compliant keys before filesystem operations.

* **Tests**
  * Added comprehensive test coverage for cache key validation, including path-traversal and empty-key rejection scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->