### PR TITLE
Document the addon to app rename and deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,17 @@ Furthermore, Bashio is used by the
 [Home Assistant Community Apps project][repository], those apps will be
 a great resource of practical examples.
 
+### Deprecation: `addon` renamed to `app`
+
+Add-ons have been rebranded to apps, so the `bashio::addon.*` functions
+(and `bashio::addons` / `bashio::addons.*`) have been renamed to
+`bashio::app.*` (and `bashio::apps` / `bashio::apps.*`).
+
+The old names still work: each keeps a deprecated alias that delegates to
+its new counterpart and logs a warning the first time it is used. Please
+migrate to the `app` names; for example, replace `bashio::addon.name`
+with `bashio::app.name`. The aliases may be removed in a future release.
+
 ## Known issues and limitations
 
 - Some parts of the Supervisor API are not implemented yet.


### PR DESCRIPTION
# Proposed Changes

Add a short Deprecation note to the README documenting the namespace rename: `bashio::addon.*` / `bashio::addons` / `bashio::addons.*` are now `bashio::app.*` / `bashio::apps` / `bashio::apps.*`. The old names still work through deprecated aliases that warn once on first use, and callers are encouraged to migrate (the aliases may be removed in a future release).

Follow-up to the rename in #260.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deprecation documentation for renamed functions. Legacy function names remain functional as deprecated aliases that emit warnings upon first use, helping users identify and migrate to the new naming convention while maintaining backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->