### PR TITLE
Add a DevContainer with the CI toolchain

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "name": "bashio",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "latest"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "lts"
+    },
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.13"
+    }
+  },
+  "onCreateCommand": "bash .devcontainer/setup.sh",
+  "postCreateCommand": "prek install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "timonwong.shellcheck",
+        "foxundermoon.shell-format",
+        "esbenp.prettier-vscode",
+        "redhat.vscode-yaml",
+        "github.vscode-pull-request-github",
+        "github.vscode-github-actions"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "shellformat.flag": "-i 4 -ci"
+      }
+    }
+  },
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Provisions the development toolchain used by the bashio CI pipeline so a
+# contributor can run the exact same checks locally inside the devcontainer.
+#
+# The GitHub CLI, Node.js (for Prettier) and Python are provided by the
+# devcontainer features. This script installs the remaining tools and pins
+# them to the versions referenced by the CI workflow and the pre-commit
+# configuration of this repository.
+# ==============================================================================
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Tool versions, kept in sync with .pre-commit-config.yaml and ci.yaml.
+readonly SHELLCHECK_VERSION="0.11.0"
+readonly SHFMT_VERSION="3.13.1"
+readonly BATS_VERSION="1.12.0"
+readonly PRETTIER_VERSION="3.8.3"
+readonly CODESPELL_VERSION="2.4.2"
+readonly YAMLLINT_VERSION="1.38.0"
+
+# Resolve the host architecture for the upstream release downloads.
+arch="$(dpkg --print-architecture)"
+case "${arch}" in
+    amd64) shellcheck_arch="x86_64" ;;
+    arm64) shellcheck_arch="aarch64" ;;
+    *)
+        echo "Unsupported architecture: ${arch}" >&2
+        exit 1
+        ;;
+esac
+
+echo "Updating package lists..."
+sudo apt-get update
+
+echo "Installing jq..."
+sudo apt-get install --yes --no-install-recommends jq
+
+echo "Installing shellcheck ${SHELLCHECK_VERSION}..."
+tmp="$(mktemp --directory)"
+curl --fail --silent --show-error --location \
+    "https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECK_VERSION}/shellcheck-v${SHELLCHECK_VERSION}.linux.${shellcheck_arch}.tar.xz" |
+    tar --extract --xz --directory "${tmp}"
+sudo install "${tmp}/shellcheck-v${SHELLCHECK_VERSION}/shellcheck" /usr/local/bin/shellcheck
+rm --recursive --force "${tmp}"
+
+echo "Installing shfmt ${SHFMT_VERSION}..."
+sudo curl --fail --silent --show-error --location \
+    --output /usr/local/bin/shfmt \
+    "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${arch}"
+sudo chmod +x /usr/local/bin/shfmt
+
+echo "Installing bats ${BATS_VERSION}..."
+tmp="$(mktemp --directory)"
+curl --fail --silent --show-error --location \
+    "https://github.com/bats-core/bats-core/archive/refs/tags/v${BATS_VERSION}.tar.gz" |
+    tar --extract --gzip --directory "${tmp}"
+sudo "${tmp}/bats-core-${BATS_VERSION}/install.sh" /usr/local
+rm --recursive --force "${tmp}"
+
+echo "Installing Prettier ${PRETTIER_VERSION}..."
+sudo npm install --global "prettier@${PRETTIER_VERSION}"
+
+echo "Installing Python based tooling (codespell, yamllint, prek)..."
+pip install --user --no-warn-script-location \
+    "codespell==${CODESPELL_VERSION}" \
+    "yamllint==${YAMLLINT_VERSION}" \
+    prek
+
+echo "Toolchain installation complete."


### PR DESCRIPTION
# Proposed Changes

Adds a `.devcontainer` (Phase 5) so contributors get the exact toolchain the CI uses and can run every check locally.

- Base: `mcr.microsoft.com/devcontainers/base:ubuntu`.
- GitHub CLI, Node (for Prettier) and Python come from official devcontainer features; `setup.sh` installs shellcheck, shfmt, bats, jq, codespell, yamllint, prettier and prek, pinned to the versions in `ci.yaml` / `.pre-commit-config.yaml`.
- `prek install` wires up the git hooks on create.
- No `npm install` / `nvm install`: the repo intentionally has no `package.json` or `.nvmrc`, so Prettier is installed globally at a pinned version.
- VS Code extensions for shellcheck, shell-format, prettier, YAML, and the GitHub PR/Actions integrations.

The `devcontainer.json` is strict JSON (prettier-clean) and `setup.sh` passes shellcheck/shfmt; CI is not affected (the container is build-time tooling only).

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced development environment configuration with containerized setup using Ubuntu base image and pre-configured tools (Node.js, Python, GitHub CLI)
  * Added automated provisioning script that installs and pins development dependencies including linters, formatters, and testing utilities
  * Configured VS Code extensions and editor customizations for improved developer experience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->