### PR TITLE
Add lib/resolution.sh covering the Supervisor resolution API

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -94,6 +94,8 @@ source "${__BASHIO_LIB_DIR}/os.sh"
 source "${__BASHIO_LIB_DIR}/pwned.sh"
 # shellcheck source=lib/repositories.sh
 source "${__BASHIO_LIB_DIR}/repositories.sh"
+# shellcheck source=lib/resolution.sh
+source "${__BASHIO_LIB_DIR}/resolution.sh"
 # shellcheck source=lib/services.sh
 source "${__BASHIO_LIB_DIR}/services.sh"
 # shellcheck source=lib/string.sh

--- a/lib/resolution.sh
+++ b/lib/resolution.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Bashio is a bash function library for use with Home Assistant apps.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in app scripts to reduce code duplication across apps.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with information from the resolution center.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::resolution() {
+    local cache_key=${1:-'resolution.info'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        bashio::cache.get "${cache_key}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    if bashio::cache.exists 'resolution.info'; then
+        info=$(bashio::cache.get 'resolution.info')
+    else
+        info=$(bashio::api.supervisor GET /resolution/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get resolution info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'resolution.info' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    bashio::cache.set "${cache_key}" "${response}"
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Returns a list of unsupported reasons.
+# ------------------------------------------------------------------------------
+function bashio::resolution.unsupported() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::resolution 'resolution.info.unsupported' '.unsupported[]'
+}
+
+# ------------------------------------------------------------------------------
+# Returns a list of unhealthy reasons.
+# ------------------------------------------------------------------------------
+function bashio::resolution.unhealthy() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::resolution 'resolution.info.unhealthy' '.unhealthy[]'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the list of current issues from the resolution center.
+# ------------------------------------------------------------------------------
+function bashio::resolution.issues() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::resolution 'resolution.info.issues' '.issues[]'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the list of current suggestions from the resolution center.
+# ------------------------------------------------------------------------------
+function bashio::resolution.suggestions() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::resolution 'resolution.info.suggestions' '.suggestions[]'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the list of available checks from the resolution center.
+# ------------------------------------------------------------------------------
+function bashio::resolution.checks() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::resolution 'resolution.info.checks' '.checks[]'
+}
+
+# ------------------------------------------------------------------------------
+# Applies a suggestion offered by the resolution center.
+#
+# Arguments:
+#   $1 UUID of the suggestion to apply
+# ------------------------------------------------------------------------------
+function bashio::resolution.suggestion.apply() {
+    local suggestion=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST "/resolution/suggestion/${suggestion}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Dismisses a suggestion offered by the resolution center.
+#
+# Arguments:
+#   $1 UUID of the suggestion to dismiss
+# ------------------------------------------------------------------------------
+function bashio::resolution.suggestion.dismiss() {
+    local suggestion=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor DELETE "/resolution/suggestion/${suggestion}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Dismisses an issue reported by the resolution center.
+#
+# Arguments:
+#   $1 UUID of the issue to dismiss
+# ------------------------------------------------------------------------------
+function bashio::resolution.issue.dismiss() {
+    local issue=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor DELETE "/resolution/issue/${issue}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Executes a check from the resolution center.
+#
+# Arguments:
+#   $1 Slug of the check to run
+# ------------------------------------------------------------------------------
+function bashio::resolution.check() {
+    local check=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST "/resolution/check/${check}/run" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Runs a backend healthcheck via the resolution center.
+# ------------------------------------------------------------------------------
+function bashio::resolution.healthcheck() {
+    bashio::log.trace "${FUNCNAME[0]}"
+
+    bashio::api.supervisor POST /resolution/healthcheck ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}

--- a/tests/resolution.bats
+++ b/tests/resolution.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/resolution.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::resolution` fetcher, jq filtering, and caching run. The cache is
+# pointed at a per-test temporary directory so tests stay isolated.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution (info fetcher)
+# ------------------------------------------------------------------------------
+
+@test "resolution fetches the info endpoint and returns the raw body" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"unsupported":[],"unhealthy":[]}'
+    }
+    run bashio::resolution
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /resolution/info false" ]
+    [ "${output}" = '{"unsupported":[],"unhealthy":[]}' ]
+}
+
+@test "resolution applies a jq filter to the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"unsupported":["apparmor"]}'
+    }
+    run bashio::resolution 'resolution.info.custom' '.unsupported[0]'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "apparmor" ]
+}
+
+@test "resolution reports failure when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::resolution
+    [ "${status}" -ne 0 ]
+}
+
+@test "resolution serves a previously cached value without calling the API" {
+    bashio::cache.set 'resolution.info.cached' 'cached-value'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::resolution 'resolution.info.cached'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-value" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.unsupported
+# ------------------------------------------------------------------------------
+
+@test "resolution.unsupported lists the unsupported reasons" {
+    bashio::api.supervisor() {
+        printf '%s' '{"unsupported":["apparmor","docker_version"]}'
+    }
+    run bashio::resolution.unsupported
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "apparmor" ]
+    [ "${lines[1]}" = "docker_version" ]
+}
+
+@test "resolution.unsupported propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::resolution.unsupported
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.unhealthy
+# ------------------------------------------------------------------------------
+
+@test "resolution.unhealthy lists the unhealthy reasons" {
+    bashio::api.supervisor() {
+        printf '%s' '{"unhealthy":["docker","supervisor"]}'
+    }
+    run bashio::resolution.unhealthy
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "docker" ]
+    [ "${lines[1]}" = "supervisor" ]
+}
+
+@test "resolution.unhealthy propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::resolution.unhealthy
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.issues
+# ------------------------------------------------------------------------------
+
+@test "resolution.issues lists the current issues" {
+    bashio::api.supervisor() {
+        printf '%s' '{"issues":[{"uuid":"abc","type":"free_space"}]}'
+    }
+    run bashio::resolution.issues
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"uuid":"abc","type":"free_space"}' ]
+}
+
+@test "resolution.issues propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::resolution.issues
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.suggestions
+# ------------------------------------------------------------------------------
+
+@test "resolution.suggestions lists the current suggestions" {
+    bashio::api.supervisor() {
+        printf '%s' '{"suggestions":[{"uuid":"def","type":"clear_full_backup"}]}'
+    }
+    run bashio::resolution.suggestions
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"uuid":"def","type":"clear_full_backup"}' ]
+}
+
+@test "resolution.suggestions propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::resolution.suggestions
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.checks
+# ------------------------------------------------------------------------------
+
+@test "resolution.checks lists the available checks" {
+    bashio::api.supervisor() {
+        printf '%s' '{"checks":[{"enabled":true,"slug":"free_space"}]}'
+    }
+    run bashio::resolution.checks
+    [ "${status}" -eq 0 ]
+    [ "${output}" = '{"enabled":true,"slug":"free_space"}' ]
+}
+
+@test "resolution.checks propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::resolution.checks
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.suggestion.apply
+# ------------------------------------------------------------------------------
+
+@test "resolution.suggestion.apply posts to the suggestion endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::resolution.suggestion.apply "abcd-1234"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /resolution/suggestion/abcd-1234" ]
+}
+
+@test "resolution.suggestion.apply propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::resolution.suggestion.apply "abcd-1234" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.suggestion.dismiss
+# ------------------------------------------------------------------------------
+
+@test "resolution.suggestion.dismiss deletes the suggestion endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::resolution.suggestion.dismiss "abcd-1234"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /resolution/suggestion/abcd-1234" ]
+}
+
+@test "resolution.suggestion.dismiss propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::resolution.suggestion.dismiss "abcd-1234" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.issue.dismiss
+# ------------------------------------------------------------------------------
+
+@test "resolution.issue.dismiss deletes the issue endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::resolution.issue.dismiss "ef01-5678"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /resolution/issue/ef01-5678" ]
+}
+
+@test "resolution.issue.dismiss propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::resolution.issue.dismiss "ef01-5678" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.check
+# ------------------------------------------------------------------------------
+
+@test "resolution.check posts to the check run endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::resolution.check "free_space"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /resolution/check/free_space/run" ]
+}
+
+@test "resolution.check propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::resolution.check "free_space" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::resolution.healthcheck
+# ------------------------------------------------------------------------------
+
+@test "resolution.healthcheck posts to the healthcheck endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::resolution.healthcheck
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /resolution/healthcheck" ]
+}
+
+@test "resolution.healthcheck propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::resolution.healthcheck || rc=$?
+    [ "${rc}" -ne 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

Adds `lib/resolution.sh`, covering the Resolution Center API: a cached `bashio::resolution` info fetcher with getters (unsupported, unhealthy, issues, suggestions, checks), plus apply/dismiss suggestion, dismiss issue, run a check, and healthcheck.

The request/response shapes were verified against the Supervisor source (`supervisor/api/resolution.py`). State-changing calls propagate API failures and flush the cache; getters cache and accept an optional jq filter, matching the existing modules. 24 tests.

Part of the effort to make bashio feature-complete against the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Bashio resolution center module with comprehensive helper functions for interacting with Home Assistant Supervisor's resolution system. Enables management of resolution information through multiple operations: fetch resolution data, apply and dismiss suggestions, dismiss issues, run diagnostic health checks, and retrieve lists of unsupported or unhealthy items and available checks, all with built-in caching support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->