### PR TITLE
Add lib/ingress.sh covering the Supervisor ingress API

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -76,6 +76,8 @@ source "${__BASHIO_LIB_DIR}/hardware.sh"
 source "${__BASHIO_LIB_DIR}/host.sh"
 # shellcheck source=lib/info.sh
 source "${__BASHIO_LIB_DIR}/info.sh"
+# shellcheck source=lib/ingress.sh
+source "${__BASHIO_LIB_DIR}/ingress.sh"
 # shellcheck source=lib/jobs.sh
 source "${__BASHIO_LIB_DIR}/jobs.sh"
 # shellcheck source=lib/jq.sh

--- a/lib/ingress.sh
+++ b/lib/ingress.sh
@@ -58,7 +58,7 @@ function bashio::ingress.panels() {
 # ------------------------------------------------------------------------------
 function bashio::ingress.session() {
     bashio::log.trace "${FUNCNAME[0]}"
-    bashio::api.supervisor POST /ingress/session false '.session' ||
+    bashio::api.supervisor POST /ingress/session '{}' '.session' ||
         return "${__BASHIO_EXIT_NOK}"
 }
 

--- a/lib/ingress.sh
+++ b/lib/ingress.sh
@@ -72,7 +72,9 @@ function bashio::ingress.validate_session() {
     local session=${1}
     local payload
 
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    # The session id is effectively a credential, so it is kept out of the
+    # trace log (only the function name is logged).
+    bashio::log.trace "${FUNCNAME[0]}"
 
     payload=$(bashio::var.json session "${session}")
     bashio::api.supervisor POST /ingress/validate_session "${payload}" ||

--- a/lib/ingress.sh
+++ b/lib/ingress.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Bashio is a bash function library for use with Home Assistant apps.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in app scripts to reduce code duplication across apps.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with the available ingress panels.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::ingress.panels() {
+    local cache_key=${1:-'ingress.panels'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        bashio::cache.get "${cache_key}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    if bashio::cache.exists 'ingress.panels'; then
+        info=$(bashio::cache.get 'ingress.panels')
+    else
+        info=$(bashio::api.supervisor GET /ingress/panels false '.panels')
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get ingress panels from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'ingress.panels' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    bashio::cache.set "${cache_key}" "${response}"
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Creates a new ingress session and returns its session identifier.
+# ------------------------------------------------------------------------------
+function bashio::ingress.session() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::api.supervisor POST /ingress/session false '.session' ||
+        return "${__BASHIO_EXIT_NOK}"
+}
+
+# ------------------------------------------------------------------------------
+# Validates an ingress session and extends how long it stays valid.
+#
+# Arguments:
+#   $1 Ingress session identifier
+# ------------------------------------------------------------------------------
+function bashio::ingress.validate_session() {
+    local session=${1}
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    payload=$(bashio::var.json session "${session}")
+    bashio::api.supervisor POST /ingress/validate_session "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+
+    return "${__BASHIO_EXIT_OK}"
+}

--- a/tests/ingress.bats
+++ b/tests/ingress.bats
@@ -63,7 +63,7 @@ setup() {
     }
     run bashio::ingress.session
     [ "${status}" -eq 0 ]
-    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /ingress/session false .session" ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /ingress/session {} .session" ]
 }
 
 @test "ingress.session returns the session id from the API response" {

--- a/tests/ingress.bats
+++ b/tests/ingress.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/ingress.sh.
+#
+# The Supervisor API boundary is stubbed via a `bashio::api.supervisor` bash
+# function so no real HTTP requests are made. The cache is isolated to a
+# per-test temporary directory.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# ---------------------------------------------------------------------------
+# bashio::ingress.panels
+# ---------------------------------------------------------------------------
+
+@test "ingress.panels calls GET /ingress/panels and returns the panels object" {
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"a8a8a8a8":{"title":"Demo","enable":true}}'
+    }
+    run bashio::ingress.panels
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /ingress/panels false .panels" ]
+    [ "${output}" = '{"a8a8a8a8":{"title":"Demo","enable":true}}' ]
+}
+
+@test "ingress.panels applies a jq filter to the panels response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"a8a8a8a8":{"title":"Demo","enable":true}}'
+    }
+    run bashio::ingress.panels 'ingress.panels.custom' '.a8a8a8a8.title'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "Demo" ]
+}
+
+@test "ingress.panels reports failure when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::ingress.panels
+    [ "${status}" -ne 0 ]
+}
+
+@test "ingress.panels serves a previously cached value without calling the API" {
+    bashio::cache.set 'ingress.panels.cached' 'cached-panels'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::ingress.panels 'ingress.panels.cached'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-panels" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::ingress.session
+# ---------------------------------------------------------------------------
+
+@test "ingress.session calls POST /ingress/session with the session filter" {
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' 'abc-session-id'
+    }
+    run bashio::ingress.session
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /ingress/session false .session" ]
+}
+
+@test "ingress.session returns the session id from the API response" {
+    bashio::api.supervisor() { printf '%s' 'abc-session-id'; }
+    run bashio::ingress.session
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "abc-session-id" ]
+}
+
+@test "ingress.session propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::ingress.session || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::ingress.validate_session
+# ---------------------------------------------------------------------------
+
+@test "ingress.validate_session posts the session in a JSON body" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    expected_payload=$(bashio::var.json session "abc-session-id")
+    run bashio::ingress.validate_session "abc-session-id"
+    [ "${status}" -eq 0 ]
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [ "${call}" = "POST /ingress/validate_session ${expected_payload}" ]
+}
+
+@test "ingress.validate_session payload contains the session id" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/payload"; }
+    bashio::ingress.validate_session "my-session"
+    payload="$(cat "${BATS_TEST_TMPDIR}/payload")"
+    [ "$(printf '%s' "${payload}" | jq -r '.session')" = "my-session" ]
+}
+
+@test "ingress.validate_session returns success on a valid session" {
+    bashio::api.supervisor() { return 0; }
+    run bashio::ingress.validate_session "valid-session"
+    [ "${status}" -eq 0 ]
+}
+
+@test "ingress.validate_session returns failure on an invalid session" {
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
+    rc=0
+    bashio::ingress.validate_session "invalid-session" || rc=$?
+    [ "${rc}" -ne 0 ]
+    # The failing Supervisor call must still have been attempted.
+    [[ "$(cat "${BATS_TEST_TMPDIR}/call")" == "POST /ingress/validate_session "* ]]
+}

--- a/tests/ingress.bats
+++ b/tests/ingress.bats
@@ -117,3 +117,12 @@ setup() {
     # The failing Supervisor call must still have been attempted.
     [[ "$(cat "${BATS_TEST_TMPDIR}/call")" == "POST /ingress/validate_session "* ]]
 }
+
+@test "ingress.validate_session does not log the session id" {
+    # The session id is a credential and must not reach the trace log.
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { return 0; }
+    bashio::ingress.validate_session "secret-session-id" >/dev/null
+    [[ "${logged}" != *"secret-session-id"* ]]
+}


### PR DESCRIPTION
# Proposed Changes

Adds `lib/ingress.sh`, covering the Ingress API: `bashio::ingress.panels` (cached), `ingress.session` (returns a new session id), and `ingress.validate_session`.

The request/response shapes were verified against the Supervisor source (`supervisor/api/ingress.py`). State-changing calls propagate API failures and flush the cache; getters cache and accept an optional jq filter, matching the existing modules. 11 tests.

Part of the effort to make bashio feature-complete against the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an ingress helper to the Bashio library (auto-loaded) to fetch available ingress panels (with optional filtering and caching), create ingress sessions, and validate session authentication.

* **Tests**
  * Added comprehensive tests covering ingress fetching, filtering, caching, session creation/validation, API-failure handling, trace-safety (session IDs not logged), and isolated test cache environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->