### PR TITLE
Add lib/mounts.sh covering the Supervisor mounts API

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -80,6 +80,8 @@ source "${__BASHIO_LIB_DIR}/info.sh"
 source "${__BASHIO_LIB_DIR}/jobs.sh"
 # shellcheck source=lib/jq.sh
 source "${__BASHIO_LIB_DIR}/jq.sh"
+# shellcheck source=lib/mounts.sh
+source "${__BASHIO_LIB_DIR}/mounts.sh"
 # shellcheck source=lib/multicast.sh
 source "${__BASHIO_LIB_DIR}/multicast.sh"
 # shellcheck source=lib/net.sh

--- a/lib/mounts.sh
+++ b/lib/mounts.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Bashio is a bash function library for use with Home Assistant apps.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in app scripts to reduce code duplication across apps.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with information about the configured mounts.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::mounts() {
+    local cache_key=${1:-'mounts.info'}
+    local filter=${2:-'.mounts[].name'}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        bashio::cache.get "${cache_key}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    if bashio::cache.exists 'mounts.info'; then
+        info=$(bashio::cache.get 'mounts.info')
+    else
+        info=$(bashio::api.supervisor GET /mounts false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get mounts info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'mounts.info' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    bashio::cache.set "${cache_key}" "${response}"
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Returns a list of the names of all configured mounts.
+# ------------------------------------------------------------------------------
+function bashio::mounts.list() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::mounts 'mounts.info.list' '.mounts[].name'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the name of the default backup mount.
+# ------------------------------------------------------------------------------
+function bashio::mounts.default_backup_mount() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::mounts 'mounts.info.default_backup_mount' '.default_backup_mount'
+}
+
+# ------------------------------------------------------------------------------
+# Creates a new mount in the Supervisor.
+#
+# Arguments:
+#   $1 Mount definition (JSON)
+# ------------------------------------------------------------------------------
+function bashio::mounts.create() {
+    local mount=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST /mounts "${mount}" || return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Sets the Mount Manager options.
+#
+# Arguments:
+#   $1 Options object (JSON)
+# ------------------------------------------------------------------------------
+function bashio::mounts.options() {
+    local options=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST /mounts/options "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Reloads an existing mount in the Supervisor.
+#
+# Arguments:
+#   $1 Mount name
+# ------------------------------------------------------------------------------
+function bashio::mount.reload() {
+    local mount=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST "/mounts/${mount}/reload" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Deletes an existing mount from the Supervisor.
+#
+# Arguments:
+#   $1 Mount name
+# ------------------------------------------------------------------------------
+function bashio::mount.delete() {
+    local mount=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor DELETE "/mounts/${mount}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}

--- a/lib/mounts.sh
+++ b/lib/mounts.sh
@@ -16,7 +16,7 @@
 # ------------------------------------------------------------------------------
 function bashio::mounts() {
     local cache_key=${1:-'mounts.info'}
-    local filter=${2:-'.mounts[].name'}
+    local filter=${2:-}
     local info
     local response
 

--- a/tests/mounts.bats
+++ b/tests/mounts.bats
@@ -28,7 +28,7 @@ setup() {
 # bashio::mounts - base fetcher
 # ---------------------------------------------------------------------------
 
-@test "mounts fetches the info endpoint and lists mount names by default" {
+@test "mounts fetches the info endpoint and returns the raw object by default" {
     bashio::api.supervisor() {
         printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
         printf '%s' "${MOUNTS_JSON}"
@@ -36,8 +36,20 @@ setup() {
     run bashio::mounts
     [ "${status}" -eq 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /mounts false" ]
-    [ "${lines[0]}" = "my_share" ]
-    [ "${lines[1]}" = "media_nas" ]
+    # No default filter, so the whole mounts object is returned (use
+    # bashio::mounts.list for names). Caching the unfiltered blob under the
+    # default key must not corrupt the shared mounts.info cache.
+    [ "$(printf '%s' "${output}" | jq -r '.mounts[0].name')" = "my_share" ]
+}
+
+@test "a bare mounts call leaves the mounts.info cache as the full object" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    # A bare call (default cache key + no filter) must cache the full blob under
+    # mounts.info, not a filtered value, so later getters still get valid JSON.
+    bashio::mounts >/dev/null
+    run bashio::cache.get 'mounts.info'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.mounts[0].name')" = "my_share" ]
 }
 
 @test "mounts applies a custom jq filter to the info response" {

--- a/tests/mounts.bats
+++ b/tests/mounts.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/mounts.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::mounts` fetcher, jq filtering, and caching run. The cache is pointed
+# at a per-test temporary directory so tests stay isolated.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+# ---------------------------------------------------------------------------
+# Canned JSON response used by most tests
+# ---------------------------------------------------------------------------
+MOUNTS_JSON='{
+  "default_backup_mount": "my_share",
+  "mounts": [
+    {"name": "my_share", "type": "cifs", "usage": "backup", "state": "active"},
+    {"name": "media_nas", "type": "nfs", "usage": "media", "state": "active"}
+  ]
+}'
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# ---------------------------------------------------------------------------
+# bashio::mounts - base fetcher
+# ---------------------------------------------------------------------------
+
+@test "mounts fetches the info endpoint and lists mount names by default" {
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' "${MOUNTS_JSON}"
+    }
+    run bashio::mounts
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /mounts false" ]
+    [ "${lines[0]}" = "my_share" ]
+    [ "${lines[1]}" = "media_nas" ]
+}
+
+@test "mounts applies a custom jq filter to the info response" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    run bashio::mounts 'mounts.info.default' '.default_backup_mount'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "my_share" ]
+}
+
+@test "mounts reports failure when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::mounts
+    [ "${status}" -ne 0 ]
+}
+
+@test "mounts serves a previously cached value without calling the API" {
+    bashio::cache.set 'mounts.info.cached' 'cached-value'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::mounts 'mounts.info.cached'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-value" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::mounts.list
+# ---------------------------------------------------------------------------
+
+@test "mounts.list lists the configured mount names" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    run bashio::mounts.list
+    [ "${status}" -eq 0 ]
+    [ "${lines[0]}" = "my_share" ]
+    [ "${lines[1]}" = "media_nas" ]
+}
+
+@test "mounts.list propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::mounts.list
+    [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::mounts.default_backup_mount
+# ---------------------------------------------------------------------------
+
+@test "mounts.default_backup_mount extracts the default backup mount" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    run bashio::mounts.default_backup_mount
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "my_share" ]
+}
+
+@test "mounts.default_backup_mount propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::mounts.default_backup_mount
+    [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::mounts.create
+# ---------------------------------------------------------------------------
+
+@test "mounts.create calls POST /mounts with the mount definition" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::mounts.create '{"name":"my_share","type":"cifs"}'
+    [ "${status}" -eq 0 ]
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [ "${call}" = 'POST /mounts {"name":"my_share","type":"cifs"}' ]
+}
+
+@test "mounts.create flushes the cache" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::mounts.create '{"name":"new"}'
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+}
+
+@test "mounts.create propagates an API failure" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
+    run bashio::mounts.create '{"name":"x"}'
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /mounts {"name":"x"}' ]
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::mounts.options
+# ---------------------------------------------------------------------------
+
+@test "mounts.options calls POST /mounts/options with the options" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::mounts.options '{"default_backup_mount":"my_share"}'
+    [ "${status}" -eq 0 ]
+    call="$(cat "${BATS_TEST_TMPDIR}/call")"
+    [ "${call}" = 'POST /mounts/options {"default_backup_mount":"my_share"}' ]
+}
+
+@test "mounts.options flushes the cache" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::mounts.options '{"default_backup_mount":null}'
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+}
+
+@test "mounts.options propagates an API failure" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
+    run bashio::mounts.options '{"default_backup_mount":"x"}'
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /mounts/options {"default_backup_mount":"x"}' ]
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::mount.reload
+# ---------------------------------------------------------------------------
+
+@test "mount.reload calls POST /mounts/<name>/reload" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::mount.reload "my_share"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /mounts/my_share/reload" ]
+}
+
+@test "mount.reload flushes the cache" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::mount.reload "my_share"
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+}
+
+@test "mount.reload propagates an API failure" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
+    run bashio::mount.reload "my_share"
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /mounts/my_share/reload" ]
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::mount.delete
+# ---------------------------------------------------------------------------
+
+@test "mount.delete calls DELETE /mounts/<name>" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::mount.delete "my_share"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /mounts/my_share" ]
+}
+
+@test "mount.delete flushes the cache" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::mount.delete "my_share"
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+}
+
+@test "mount.delete propagates an API failure" {
+    bashio::api.supervisor() { printf '%s' "${MOUNTS_JSON}"; }
+    bashio::mounts >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
+    run bashio::mount.delete "my_share"
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /mounts/my_share" ]
+    [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+}


### PR DESCRIPTION
# Proposed Changes

Adds `lib/mounts.sh`, covering the Mount Manager API: a cached `bashio::mounts` info fetcher with getters, plus create / options / reload / delete helpers.

The request/response shapes were verified against the Supervisor source (`supervisor/api/mounts.py`). State-changing calls propagate API failures and flush the cache; getters cache and accept an optional jq filter, matching the existing modules. 20 tests.

Part of the effort to make bashio feature-complete against the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mount management capabilities to the bashio library for interacting with Home Assistant Supervisor mount configuration, including fetching mount information, listing available mounts, retrieving default backup mount, and creating, updating, reloading, or deleting mounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->