### PR TITLE
Add lib/docker.sh covering the Supervisor docker API

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -68,6 +68,8 @@ source "${__BASHIO_LIB_DIR}/debug.sh"
 source "${__BASHIO_LIB_DIR}/exit.sh"
 # shellcheck source=lib/discovery.sh
 source "${__BASHIO_LIB_DIR}/discovery.sh"
+# shellcheck source=lib/docker.sh
+source "${__BASHIO_LIB_DIR}/docker.sh"
 # shellcheck source=lib/dns.sh
 source "${__BASHIO_LIB_DIR}/dns.sh"
 # shellcheck source=lib/hardware.sh

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Bashio is a bash function library for use with Home Assistant apps.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in app scripts to reduce code duplication across apps.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with generic information about the Docker configuration.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::docker() {
+    local cache_key=${1:-'docker.info'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        bashio::cache.get "${cache_key}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    if bashio::cache.exists 'docker.info'; then
+        info=$(bashio::cache.get 'docker.info')
+    else
+        info=$(bashio::api.supervisor GET /docker/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get docker info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'docker.info' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    bashio::cache.set "${cache_key}" "${response}"
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Returns the version of Docker in use.
+# ------------------------------------------------------------------------------
+function bashio::docker.version() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::docker 'docker.info.version' '.version'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the storage driver Docker is using.
+# ------------------------------------------------------------------------------
+function bashio::docker.storage() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::docker 'docker.info.storage' '.storage'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the logging driver Docker is using.
+# ------------------------------------------------------------------------------
+function bashio::docker.logging() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::docker 'docker.info.logging' '.logging'
+}
+
+# ------------------------------------------------------------------------------
+# Returns whether or not IPv6 is enabled for the Docker network.
+# ------------------------------------------------------------------------------
+function bashio::docker.enable_ipv6() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::docker 'docker.info.enable_ipv6' '.enable_ipv6 // false'
+}
+
+# ------------------------------------------------------------------------------
+# Returns the MTU configured for the Docker network.
+# ------------------------------------------------------------------------------
+function bashio::docker.mtu() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::docker 'docker.info.mtu' '.mtu'
+}
+
+# ------------------------------------------------------------------------------
+# Sets Docker options.
+#
+# Arguments:
+#   $1 Options object (JSON)
+# ------------------------------------------------------------------------------
+function bashio::docker.options() {
+    local options=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST /docker/options "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with the configured Docker registries.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::docker.registries() {
+    local cache_key=${1:-'docker.registries'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        bashio::cache.get "${cache_key}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    if bashio::cache.exists 'docker.registries'; then
+        info=$(bashio::cache.get 'docker.registries')
+    else
+        info=$(bashio::api.supervisor GET /docker/registries false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get docker registries from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'docker.registries' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    bashio::cache.set "${cache_key}" "${response}"
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Adds a Docker registry.
+#
+# Arguments:
+#   $1 Hostname of the registry
+#   $2 Username for the registry
+#   $3 Password for the registry
+# ------------------------------------------------------------------------------
+function bashio::docker.registries.add() {
+    local hostname=${1}
+    local username=${2}
+    local password=${3}
+    local credentials
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "${hostname}"
+
+    # The API expects {"<hostname>": {"username": ..., "password": ...}}.
+    # Build it with bashio::var.json so untrusted values are JSON escaped
+    # instead of being interpolated into a jq program.
+    credentials=$(bashio::var.json \
+        username "${username}" \
+        password "${password}")
+    payload=$(bashio::var.json "${hostname}" "^${credentials}")
+
+    bashio::api.supervisor POST /docker/registries "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Removes a Docker registry.
+#
+# Arguments:
+#   $1 Hostname of the registry
+# ------------------------------------------------------------------------------
+function bashio::docker.registries.remove() {
+    local hostname=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor DELETE "/docker/registries/${hostname}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}

--- a/tests/docker.bats
+++ b/tests/docker.bats
@@ -1,0 +1,309 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/docker.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::docker`/`bashio::docker.registries` fetchers, jq filtering, and
+# caching run. The cache is pointed at a per-test temporary directory so tests
+# stay isolated.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker (info fetcher)
+# ------------------------------------------------------------------------------
+
+@test "docker fetches the info endpoint and returns the raw body" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"version":"24.0.7","storage":"overlay2"}'
+    }
+    run bashio::docker
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /docker/info false" ]
+    [ "${output}" = '{"version":"24.0.7","storage":"overlay2"}' ]
+}
+
+@test "docker applies a jq filter to the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"24.0.7","storage":"overlay2"}'
+    }
+    run bashio::docker 'docker.info.custom' '.storage'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "overlay2" ]
+}
+
+@test "docker reports failure when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::docker
+    [ "${status}" -ne 0 ]
+}
+
+@test "docker serves a previously cached value without calling the API" {
+    bashio::cache.set 'docker.info.cached' 'cached-value'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::docker 'docker.info.cached'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-value" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.version
+# ------------------------------------------------------------------------------
+
+@test "docker.version extracts the version from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"24.0.7"}'
+    }
+    run bashio::docker.version
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "24.0.7" ]
+}
+
+@test "docker.version propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::docker.version
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.storage
+# ------------------------------------------------------------------------------
+
+@test "docker.storage extracts the storage driver from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"storage":"overlay2"}'
+    }
+    run bashio::docker.storage
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "overlay2" ]
+}
+
+@test "docker.storage propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::docker.storage
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.logging
+# ------------------------------------------------------------------------------
+
+@test "docker.logging extracts the logging driver from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"logging":"journald"}'
+    }
+    run bashio::docker.logging
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "journald" ]
+}
+
+@test "docker.logging propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::docker.logging
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.enable_ipv6
+# ------------------------------------------------------------------------------
+
+@test "docker.enable_ipv6 returns the boolean from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"enable_ipv6":true}'
+    }
+    run bashio::docker.enable_ipv6
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "docker.enable_ipv6 defaults to false when the key is missing" {
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"24.0.7"}'
+    }
+    run bashio::docker.enable_ipv6
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+}
+
+@test "docker.enable_ipv6 propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::docker.enable_ipv6
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.mtu
+# ------------------------------------------------------------------------------
+
+@test "docker.mtu extracts the MTU from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"mtu":1500}'
+    }
+    run bashio::docker.mtu
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "1500" ]
+}
+
+@test "docker.mtu propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::docker.mtu
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.options
+# ------------------------------------------------------------------------------
+
+@test "docker.options posts the options object to the options endpoint" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::docker.options '{"enable_ipv6":true}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /docker/options {"enable_ipv6":true}' ]
+}
+
+@test "docker.options flushes the cache" {
+    # Prime the cache first.
+    bashio::api.supervisor() { printf '%s' '{"version":"24.0.7"}'; }
+    bashio::docker >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/docker.info.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::docker.options '{"mtu":1500}'
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+}
+
+@test "docker.options propagates an API failure" {
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
+    run bashio::docker.options '{"mtu":1500}'
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /docker/options {"mtu":1500}' ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.registries (registries fetcher)
+# ------------------------------------------------------------------------------
+
+@test "docker.registries fetches the registries endpoint and returns the raw body" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"registries":{"hub.docker.com":{"username":"alice"}}}'
+    }
+    run bashio::docker.registries
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /docker/registries false" ]
+    [ "${output}" = '{"registries":{"hub.docker.com":{"username":"alice"}}}' ]
+}
+
+@test "docker.registries applies a jq filter to the response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"registries":{"hub.docker.com":{"username":"alice"}}}'
+    }
+    run bashio::docker.registries 'docker.registries.names' '.registries | keys[]'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "hub.docker.com" ]
+}
+
+@test "docker.registries reports failure when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::docker.registries
+    [ "${status}" -ne 0 ]
+}
+
+@test "docker.registries serves a previously cached value without calling the API" {
+    bashio::cache.set 'docker.registries.cached' 'cached-registries'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::docker.registries 'docker.registries.cached'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-registries" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.registries.add
+# ------------------------------------------------------------------------------
+
+@test "docker.registries.add posts the exact nested credentials body" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::docker.registries.add "hub.docker.com" "alice" "s3cret"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = \
+        'POST /docker/registries {"hub.docker.com":{"username":"alice","password":"s3cret"}}' ]
+}
+
+@test "docker.registries.add JSON escapes hostile credential values" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::docker.registries.add 'reg"x' 'a"b' 'c\d'
+    [ "${status}" -eq 0 ]
+    # The posted body must be valid JSON with the values preserved verbatim.
+    body="$(cat "${BATS_TEST_TMPDIR}/body")"
+    [ "$(printf '%s' "${body}" | jq -r 'keys[0]')" = 'reg"x' ]
+    [ "$(printf '%s' "${body}" | jq -r '.["reg\"x"].username')" = 'a"b' ]
+    [ "$(printf '%s' "${body}" | jq -r '.["reg\"x"].password')" = 'c\d' ]
+}
+
+@test "docker.registries.add flushes the cache" {
+    # Prime the cache first.
+    bashio::api.supervisor() {
+        printf '%s' '{"registries":{"hub.docker.com":{"username":"alice"}}}'
+    }
+    bashio::docker.registries >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/docker.registries.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::docker.registries.add "hub.docker.com" "alice" "s3cret"
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+}
+
+@test "docker.registries.add propagates an API failure" {
+    bashio::api.supervisor() {
+        printf '%s' "$2" >"${BATS_TEST_TMPDIR}/endpoint"
+        return 1
+    }
+    run bashio::docker.registries.add "hub.docker.com" "alice" "s3cret"
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/endpoint")" = "/docker/registries" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::docker.registries.remove
+# ------------------------------------------------------------------------------
+
+@test "docker.registries.remove deletes the registry by hostname" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::docker.registries.remove "hub.docker.com"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /docker/registries/hub.docker.com" ]
+}
+
+@test "docker.registries.remove flushes the cache" {
+    # Prime the cache first.
+    bashio::api.supervisor() {
+        printf '%s' '{"registries":{"hub.docker.com":{"username":"alice"}}}'
+    }
+    bashio::docker.registries >/dev/null
+    [ -f "${__BASHIO_CACHE_DIR}/docker.registries.cache" ]
+
+    bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
+    bashio::docker.registries.remove "hub.docker.com"
+    [ ! -d "${__BASHIO_CACHE_DIR}" ]
+}
+
+@test "docker.registries.remove propagates an API failure" {
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
+        return 1
+    }
+    run bashio::docker.registries.remove "hub.docker.com"
+    [ "${status}" -ne 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /docker/registries/hub.docker.com" ]
+}


### PR DESCRIPTION
# Proposed Changes

Adds `lib/docker.sh`, covering the Docker API: a cached `bashio::docker` info fetcher with getters, an options setter, and registry management (list / add / remove). Registry credentials are JSON-escaped via bashio::var.json, never interpolated into a jq program.

The request/response shapes were verified against the Supervisor source (`supervisor/api/docker.py`). State-changing calls propagate API failures and flush the cache; getters cache and accept an optional jq filter, matching the existing modules. 29 tests.

Part of the effort to make bashio feature-complete against the Supervisor API.

## Related Issues

>