### PR TITLE
Add lib/security.sh covering the Supervisor security API

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -94,6 +94,8 @@ source "${__BASHIO_LIB_DIR}/os.sh"
 source "${__BASHIO_LIB_DIR}/pwned.sh"
 # shellcheck source=lib/repositories.sh
 source "${__BASHIO_LIB_DIR}/repositories.sh"
+# shellcheck source=lib/security.sh
+source "${__BASHIO_LIB_DIR}/security.sh"
 # shellcheck source=lib/services.sh
 source "${__BASHIO_LIB_DIR}/services.sh"
 # shellcheck source=lib/string.sh

--- a/lib/security.sh
+++ b/lib/security.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Bashio is a bash function library for use with Home Assistant apps.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in app scripts to reduce code duplication across apps.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with generic Supervisor security information.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::security() {
+    local cache_key=${1:-'security.info'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        bashio::cache.get "${cache_key}"
+        return "${__BASHIO_EXIT_OK}"
+    fi
+
+    if bashio::cache.exists 'security.info'; then
+        info=$(bashio::cache.get 'security.info')
+    else
+        info=$(bashio::api.supervisor GET /security/info false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get security info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'security.info' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    bashio::cache.set "${cache_key}" "${response}"
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Sets one or more security options on the Supervisor.
+#
+# Arguments:
+#   $1 Options to set (JSON object)
+# ------------------------------------------------------------------------------
+function bashio::security.options() {
+    local options=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST /security/options "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Returns or sets whether or not pwned password checks are enabled.
+#
+# Arguments:
+#   $1 True to enable pwned checks, false otherwise (optional).
+# ------------------------------------------------------------------------------
+function bashio::security.pwned() {
+    local pwned=${1:-}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::var.has_value "${pwned}"; then
+        pwned=$(bashio::var.json pwned "^${pwned}")
+        bashio::api.supervisor POST /security/options "${pwned}" ||
+            return "${__BASHIO_EXIT_NOK}"
+        bashio::cache.flush_all
+    else
+        bashio::security 'security.info.pwned' '.pwned // false'
+    fi
+}
+
+# ------------------------------------------------------------------------------
+# Returns or sets whether or not security is forced.
+#
+# Arguments:
+#   $1 True to force security, false otherwise (optional).
+# ------------------------------------------------------------------------------
+function bashio::security.force_security() {
+    local force=${1:-}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::var.has_value "${force}"; then
+        force=$(bashio::var.json force_security "^${force}")
+        bashio::api.supervisor POST /security/options "${force}" ||
+            return "${__BASHIO_EXIT_NOK}"
+        bashio::cache.flush_all
+    else
+        bashio::security 'security.info.force_security' '.force_security // false'
+    fi
+}

--- a/lib/security.sh
+++ b/lib/security.sh
@@ -81,7 +81,13 @@ function bashio::security.pwned() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${pwned}"; then
-        pwned=$(bashio::var.json pwned "^${pwned}")
+        # Normalize to a strict boolean so an arbitrary value cannot inject
+        # extra fields into the options JSON through the raw-JSON prefix.
+        if bashio::var.true "${pwned}"; then
+            pwned=$(bashio::var.json pwned "^true")
+        else
+            pwned=$(bashio::var.json pwned "^false")
+        fi
         bashio::api.supervisor POST /security/options "${pwned}" ||
             return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all
@@ -102,7 +108,13 @@ function bashio::security.force_security() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${force}"; then
-        force=$(bashio::var.json force_security "^${force}")
+        # Normalize to a strict boolean so an arbitrary value cannot inject
+        # extra fields into the options JSON through the raw-JSON prefix.
+        if bashio::var.true "${force}"; then
+            force=$(bashio::var.json force_security "^true")
+        else
+            force=$(bashio::var.json force_security "^false")
+        fi
         bashio::api.supervisor POST /security/options "${force}" ||
             return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all

--- a/tests/security.bats
+++ b/tests/security.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/security.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::security` fetcher, jq filtering, and caching run. The cache is
+# pointed at a per-test temporary directory so tests stay isolated.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+# ------------------------------------------------------------------------------
+# bashio::security (info fetcher)
+# ------------------------------------------------------------------------------
+
+@test "security fetches the info endpoint and returns the raw body" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"pwned":true,"force_security":false}'
+    }
+    run bashio::security
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /security/info false" ]
+    [ "${output}" = '{"pwned":true,"force_security":false}' ]
+}
+
+@test "security applies a jq filter to the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"pwned":true,"force_security":false}'
+    }
+    run bashio::security 'security.info.custom' '.pwned'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "security reports failure when the API call fails" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::security
+    [ "${status}" -ne 0 ]
+}
+
+@test "security serves a previously cached value without calling the API" {
+    bashio::cache.set 'security.info.cached' 'cached-value'
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::security 'security.info.cached'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "cached-value" ]
+    [ ! -f "${BATS_TEST_TMPDIR}/call" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::security.options
+# ------------------------------------------------------------------------------
+
+@test "security.options posts the given JSON to the options endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::security.options '{"force_security":true}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /security/options {"force_security":true}' ]
+}
+
+@test "security.options propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::security.options '{"force_security":true}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "security.options flushes the cache after a successful set" {
+    bashio::cache.set 'security.info' 'stale'
+    bashio::api.supervisor() { return 0; }
+    run bashio::security.options '{"pwned":false}'
+    [ "${status}" -eq 0 ]
+    run bashio::cache.exists 'security.info'
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::security.pwned
+# ------------------------------------------------------------------------------
+
+@test "security.pwned returns the boolean from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"pwned":true}'
+    }
+    run bashio::security.pwned
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "security.pwned defaults to false when the key is missing" {
+    bashio::api.supervisor() {
+        printf '%s' '{"force_security":true}'
+    }
+    run bashio::security.pwned
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+}
+
+@test "security.pwned with a value posts it to the options endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::security.pwned true
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /security/options {"pwned":true}' ]
+}
+
+@test "security.pwned propagates an API failure when reading" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::security.pwned
+    [ "${status}" -ne 0 ]
+}
+
+@test "security.pwned propagates an API failure when setting" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::security.pwned true || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::security.force_security
+# ------------------------------------------------------------------------------
+
+@test "security.force_security returns the boolean from the info response" {
+    bashio::api.supervisor() {
+        printf '%s' '{"force_security":true}'
+    }
+    run bashio::security.force_security
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "security.force_security defaults to false when the key is missing" {
+    bashio::api.supervisor() {
+        printf '%s' '{"pwned":true}'
+    }
+    run bashio::security.force_security
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+}
+
+@test "security.force_security with a value posts it to the options endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::security.force_security false
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /security/options {"force_security":false}' ]
+}
+
+@test "security.force_security propagates an API failure when reading" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::security.force_security
+    [ "${status}" -ne 0 ]
+}
+
+@test "security.force_security propagates an API failure when setting" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::security.force_security true || rc=$?
+    [ "${rc}" -ne 0 ]
+}

--- a/tests/security.bats
+++ b/tests/security.bats
@@ -108,6 +108,17 @@ setup() {
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /security/options {"pwned":true}' ]
 }
 
+@test "security.pwned normalizes the value and cannot inject extra options" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    # A crafted value must not break out into additional options keys; anything
+    # that is not strictly true is treated as false.
+    run bashio::security.pwned 'true,"force_security":true'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/body")" = '{"pwned":false}' ]
+    run jq -e 'has("force_security")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
 @test "security.pwned propagates an API failure when reading" {
     bashio::api.supervisor() { return 1; }
     run bashio::security.pwned


### PR DESCRIPTION
# Proposed Changes

Adds `lib/security.sh`, covering the Security API: a cached `bashio::security` info fetcher, the `pwned` and `force_security` options as get-or-set helpers, and a generic options setter. (The removed content-trust field and the gone integrity endpoint are intentionally not included.)

The request/response shapes were verified against the Supervisor source (`supervisor/api/security.py`). State-changing calls propagate API failures and flush the cache; getters cache and accept an optional jq filter, matching the existing modules. 17 tests.

Part of the effort to make bashio feature-complete against the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New security utilities for accessing and configuring Supervisor security settings, including password compromise detection and security enforcement options.

* **Tests**
  * Added comprehensive test coverage for security features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->