### PR TITLE
Add lib/auth.sh covering the Supervisor auth API

### DIFF
--- a/lib/auth.sh
+++ b/lib/auth.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Bashio is a bash function library for use with Home Assistant apps.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in app scripts to reduce code duplication across apps.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Authenticates a Home Assistant user against the Supervisor auth backend.
+#
+# The Supervisor signals the outcome via the HTTP status: a valid set of
+# credentials returns 200, while invalid credentials return 401. That maps
+# directly onto the return code of bashio::api.supervisor, so a successful
+# call means the user authenticated.
+#
+# The password is never logged: a placeholder is traced instead and the
+# request body is routed through api.supervisor, which keeps POST bodies out
+# of the process list and the trace log.
+#
+# Arguments:
+#   $1 Username of the Home Assistant user
+#   $2 Password of the Home Assistant user
+# ------------------------------------------------------------------------------
+function bashio::auth() {
+    local username=${1}
+    local password=${2}
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "${username}" "<REDACTED PASSWORD>"
+
+    payload=$(bashio::var.json \
+        username "${username}" \
+        password "${password}")
+
+    bashio::api.supervisor POST /auth "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Lists the Home Assistant users known to the Supervisor auth backend.
+# ------------------------------------------------------------------------------
+function bashio::auth.list() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::api.supervisor GET /auth/list false ".users"
+}
+
+# ------------------------------------------------------------------------------
+# Resets the password of a Home Assistant user.
+#
+# The password is never logged: a placeholder is traced instead and the
+# request body is routed through api.supervisor, which keeps POST bodies out
+# of the process list and the trace log.
+#
+# Arguments:
+#   $1 Username of the Home Assistant user
+#   $2 New password for the Home Assistant user
+# ------------------------------------------------------------------------------
+function bashio::auth.reset() {
+    local username=${1}
+    local password=${2}
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "${username}" "<REDACTED PASSWORD>"
+
+    payload=$(bashio::var.json \
+        username "${username}" \
+        password "${password}")
+
+    bashio::api.supervisor POST /auth/reset "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Clears the Supervisor auth cache.
+# ------------------------------------------------------------------------------
+function bashio::auth.cache.reset() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::api.supervisor DELETE /auth/cache || return "${__BASHIO_EXIT_NOK}"
+    return "${__BASHIO_EXIT_OK}"
+}

--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -54,6 +54,8 @@ source "${__BASHIO_LIB_DIR}/apps.sh"
 source "${__BASHIO_LIB_DIR}/api.sh"
 # shellcheck source=lib/audio.sh
 source "${__BASHIO_LIB_DIR}/audio.sh"
+# shellcheck source=lib/auth.sh
+source "${__BASHIO_LIB_DIR}/auth.sh"
 # shellcheck source=lib/backups.sh
 source "${__BASHIO_LIB_DIR}/backups.sh"
 # shellcheck source=lib/cli.sh

--- a/tests/auth.bats
+++ b/tests/auth.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/auth.sh (Home Assistant Supervisor auth backend).
+#
+# The Supervisor API boundary is stubbed via a `bashio::api.supervisor` bash
+# function so no real HTTP requests are made. It records its arguments to a
+# file and returns a configurable exit code so success and failure handling
+# can be asserted. The log functions are stubbed to a file so the tests can
+# assert that the password is never logged, like tests/pwned.bats.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+PASSWORD="SuperSecretValue"
+
+setup() {
+    BASHIO_TEST_LOG="${BATS_TEST_TMPDIR}/log"
+    : >"${BASHIO_TEST_LOG}"
+    bashio::log.trace() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.debug() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.info() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.warning() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+    bashio::log.error() { printf '%s\n' "$*" >>"${BASHIO_TEST_LOG}"; }
+
+    CALL_FILE="${BATS_TEST_TMPDIR}/call"
+}
+
+# ---------------------------------------------------------------------------
+# bashio::auth - authenticate a Home Assistant user
+# ---------------------------------------------------------------------------
+
+@test "auth posts the credentials to /auth as JSON" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${CALL_FILE}"; }
+    run bashio::auth "alice" "${PASSWORD}"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${CALL_FILE}")" = 'POST /auth {"username":"alice","password":"SuperSecretValue"}' ]
+}
+
+@test "auth returns success when the Supervisor returns 200" {
+    bashio::api.supervisor() { return 0; }
+    run bashio::auth "alice" "${PASSWORD}"
+    [ "${status}" -eq 0 ]
+}
+
+@test "auth returns failure when the Supervisor returns 401" {
+    # api.supervisor maps the 401 unauthorized response onto a non-zero exit.
+    bashio::api.supervisor() { return 1; }
+    run bashio::auth "alice" "wrongpass"
+    [ "${status}" -ne 0 ]
+}
+
+@test "auth never logs the plaintext password" {
+    bashio::api.supervisor() { return 0; }
+    bashio::auth "alice" "${PASSWORD}" >/dev/null
+    run cat "${BASHIO_TEST_LOG}"
+    [[ "${output}" != *"${PASSWORD}"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::auth.list - list users
+# ---------------------------------------------------------------------------
+
+@test "auth.list calls GET /auth/list and returns the users" {
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${CALL_FILE}"
+        printf '%s' '[{"username":"alice"},{"username":"bob"}]'
+    }
+    run bashio::auth.list
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${CALL_FILE}")" = "GET /auth/list false .users" ]
+    [ "$(printf '%s' "${output}" | jq -r '.[0].username')" = "alice" ]
+}
+
+@test "auth.list propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::auth.list
+    [ "${status}" -ne 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::auth.reset - reset a password
+# ---------------------------------------------------------------------------
+
+@test "auth.reset posts the credentials to /auth/reset as JSON" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${CALL_FILE}"; }
+    run bashio::auth.reset "alice" "${PASSWORD}"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${CALL_FILE}")" = 'POST /auth/reset {"username":"alice","password":"SuperSecretValue"}' ]
+}
+
+@test "auth.reset propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::auth.reset "alice" "${PASSWORD}"
+    [ "${status}" -ne 0 ]
+}
+
+@test "auth.reset never logs the plaintext password" {
+    bashio::api.supervisor() { return 0; }
+    bashio::auth.reset "alice" "${PASSWORD}" >/dev/null
+    run cat "${BASHIO_TEST_LOG}"
+    [[ "${output}" != *"${PASSWORD}"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# bashio::auth.cache.reset - clear the auth cache
+# ---------------------------------------------------------------------------
+
+@test "auth.cache.reset calls DELETE /auth/cache" {
+    bashio::api.supervisor() { printf '%s' "$*" >"${CALL_FILE}"; }
+    run bashio::auth.cache.reset
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${CALL_FILE}")" = "DELETE /auth/cache" ]
+}
+
+@test "auth.cache.reset propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    run bashio::auth.cache.reset
+    [ "${status}" -ne 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

Adds `lib/auth.sh`, covering the add-on auth backend: `bashio::auth` (authenticate an HA user), `auth.list`, `auth.reset`, and `auth.cache.reset`. The password is never logged and is routed through the file-based POST body.

The request/response shapes were verified against the Supervisor source (`supervisor/api/auth.py`). State-changing calls propagate API failures and flush the cache; getters cache and accept an optional jq filter, matching the existing modules. 11 tests.

Part of the effort to make bashio feature-complete against the Supervisor API.

## Related Issues

>