### PR TITLE
Fix audio.update propagation and harden option setters against JSON injection

### DIFF
--- a/lib/apps.sh
+++ b/lib/apps.sh
@@ -363,7 +363,11 @@ function bashio::app.auto_update() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${auto_update}"; then
-        auto_update=$(bashio::var.json auto_update "^${auto_update}")
+        if bashio::var.true "${auto_update}"; then
+            auto_update=$(bashio::var.json auto_update "^true")
+        else
+            auto_update=$(bashio::var.json auto_update "^false")
+        fi
         bashio::api.supervisor POST "/addons/${slug}/options" "${auto_update}" || return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all
     else
@@ -1275,7 +1279,11 @@ function bashio::app.ingress_panel() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${ingress_panel}"; then
-        ingress_panel=$(bashio::var.json ingress_panel "^${ingress_panel}")
+        if bashio::var.true "${ingress_panel}"; then
+            ingress_panel=$(bashio::var.json ingress_panel "^true")
+        else
+            ingress_panel=$(bashio::var.json ingress_panel "^false")
+        fi
         bashio::api.supervisor POST "/addons/${slug}/options" "${ingress_panel}" || return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all
     else
@@ -1300,7 +1308,11 @@ function bashio::app.watchdog() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${watchdog}"; then
-        watchdog=$(bashio::var.json watchdog "^${watchdog}")
+        if bashio::var.true "${watchdog}"; then
+            watchdog=$(bashio::var.json watchdog "^true")
+        else
+            watchdog=$(bashio::var.json watchdog "^false")
+        fi
         bashio::api.supervisor POST "/addons/${slug}/options" "${watchdog}" || return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all
     else

--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -20,9 +20,9 @@ function bashio::audio.update() {
 
     if bashio::var.has_value "${version}"; then
         version=$(bashio::var.json version "${version}")
-        bashio::api.supervisor POST /audio/update "${version}"
+        bashio::api.supervisor POST /audio/update "${version}" || return "${__BASHIO_EXIT_NOK}"
     else
-        bashio::api.supervisor POST /audio/update
+        bashio::api.supervisor POST /audio/update || return "${__BASHIO_EXIT_NOK}"
     fi
     bashio::cache.flush_all
 }

--- a/lib/backups.sh
+++ b/lib/backups.sh
@@ -30,7 +30,12 @@ function bashio::backups.freeze() {
 
     if bashio::var.has_value "${timeout}"; then
         if [[ ! "${timeout}" =~ ^(0|[1-9][0-9]*)$ ]]; then
-            bashio::log.error "Invalid timeout, expected a non-negative integer: ${timeout}"
+            # Sanitize the rejected (untrusted) value before logging it, so it
+            # cannot inject newlines or escape sequences into the log.
+            local display=${timeout//[[:cntrl:]]/?}
+            display=${display//\\/?}
+            bashio::log.error \
+                "Invalid timeout, expected a non-negative integer: '${display}'"
             return "${__BASHIO_EXIT_NOK}"
         fi
         options=$(bashio::var.json timeout "^${timeout}")
@@ -61,8 +66,12 @@ function bashio::backups.days_until_stale() {
 
     if bashio::var.has_value "${days_until_stale}"; then
         if [[ ! "${days_until_stale}" =~ ^(0|[1-9][0-9]*)$ ]]; then
+            # Sanitize the rejected (untrusted) value before logging it, so it
+            # cannot inject newlines or escape sequences into the log.
+            local display=${days_until_stale//[[:cntrl:]]/?}
+            display=${display//\\/?}
             bashio::log.error \
-                "Invalid days_until_stale, expected a non-negative integer: ${days_until_stale}"
+                "Invalid days_until_stale, expected a non-negative integer: '${display}'"
             return "${__BASHIO_EXIT_NOK}"
         fi
         days_until_stale=$(bashio::var.json days_until_stale "^${days_until_stale}")

--- a/lib/backups.sh
+++ b/lib/backups.sh
@@ -29,6 +29,10 @@ function bashio::backups.freeze() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${timeout}"; then
+        if [[ ! "${timeout}" =~ ^[0-9]+$ ]]; then
+            bashio::log.error "Invalid timeout, expected a positive integer: ${timeout}"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         options=$(bashio::var.json timeout "^${timeout}")
     fi
     bashio::api.supervisor POST /backups/freeze "${options}" || return "${__BASHIO_EXIT_NOK}"
@@ -56,6 +60,11 @@ function bashio::backups.days_until_stale() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${days_until_stale}"; then
+        if [[ ! "${days_until_stale}" =~ ^[0-9]+$ ]]; then
+            bashio::log.error \
+                "Invalid days_until_stale, expected a positive integer: ${days_until_stale}"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
         days_until_stale=$(bashio::var.json days_until_stale "^${days_until_stale}")
         bashio::api.supervisor POST "/backups/options" "${days_until_stale}" || return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all

--- a/lib/backups.sh
+++ b/lib/backups.sh
@@ -29,8 +29,8 @@ function bashio::backups.freeze() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${timeout}"; then
-        if [[ ! "${timeout}" =~ ^[0-9]+$ ]]; then
-            bashio::log.error "Invalid timeout, expected a positive integer: ${timeout}"
+        if [[ ! "${timeout}" =~ ^(0|[1-9][0-9]*)$ ]]; then
+            bashio::log.error "Invalid timeout, expected a non-negative integer: ${timeout}"
             return "${__BASHIO_EXIT_NOK}"
         fi
         options=$(bashio::var.json timeout "^${timeout}")
@@ -60,9 +60,9 @@ function bashio::backups.days_until_stale() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${days_until_stale}"; then
-        if [[ ! "${days_until_stale}" =~ ^[0-9]+$ ]]; then
+        if [[ ! "${days_until_stale}" =~ ^(0|[1-9][0-9]*)$ ]]; then
             bashio::log.error \
-                "Invalid days_until_stale, expected a positive integer: ${days_until_stale}"
+                "Invalid days_until_stale, expected a non-negative integer: ${days_until_stale}"
             return "${__BASHIO_EXIT_NOK}"
         fi
         days_until_stale=$(bashio::var.json days_until_stale "^${days_until_stale}")

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -225,7 +225,11 @@ function bashio::core.watchdog() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::var.has_value "${watchdog}"; then
-        watchdog=$(bashio::var.json watchdog "^${watchdog}")
+        if bashio::var.true "${watchdog}"; then
+            watchdog=$(bashio::var.json watchdog "^true")
+        else
+            watchdog=$(bashio::var.json watchdog "^false")
+        fi
         bashio::api.supervisor POST /core/options "${watchdog}" || return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all
     else

--- a/lib/discovery.sh
+++ b/lib/discovery.sh
@@ -19,7 +19,10 @@ function bashio::discovery() {
     local config=${2}
     local payload
 
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    # The configuration object can carry credentials (for example MQTT broker
+    # username and password), so trace only the function name and the service,
+    # never the configuration payload.
+    bashio::log.trace "${FUNCNAME[0]}" "${service}"
 
     payload=$(
         bashio::var.json \

--- a/lib/mounts.sh
+++ b/lib/mounts.sh
@@ -78,7 +78,9 @@ function bashio::mounts.default_backup_mount() {
 function bashio::mounts.create() {
     local mount=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    # A mount definition can carry credentials (CIFS/NFS username and
+    # password), so trace only the function name, never the payload.
+    bashio::log.trace "${FUNCNAME[0]}"
 
     bashio::api.supervisor POST /mounts "${mount}" || return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
@@ -93,7 +95,9 @@ function bashio::mounts.create() {
 function bashio::mounts.options() {
     local options=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    # The options object can carry mount credentials, so trace only the
+    # function name, never the payload.
+    bashio::log.trace "${FUNCNAME[0]}"
 
     bashio::api.supervisor POST /mounts/options "${options}" ||
         return "${__BASHIO_EXIT_NOK}"

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -175,7 +175,11 @@ function bashio::network.enabled() {
     bashio::log.trace "${FUNCNAME[0]}"
 
     if bashio::var.has_value "${enabled}"; then
-        enabled=$(bashio::var.json enabled "^${enabled}")
+        if bashio::var.true "${enabled}"; then
+            enabled=$(bashio::var.json enabled "^true")
+        else
+            enabled=$(bashio::var.json enabled "^false")
+        fi
         bashio::api.supervisor POST "/network/interface/${interface}/update" "${enabled}" || return "${__BASHIO_EXIT_NOK}"
         bashio::cache.flush_all
     else

--- a/tests/apps.bats
+++ b/tests/apps.bats
@@ -753,6 +753,17 @@ get_field() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "addon.auto_update normalizes the value and cannot inject extra options" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    # A crafted value must not break out into additional options keys; anything
+    # that is not strictly true is treated as false.
+    run bashio::app.auto_update "alpha" 'true,"rootfs_path":"/"'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/body")" = '{"auto_update":false}' ]
+    run jq -e 'has("rootfs_path")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
 @test "addon.boot reads the value when no second argument is given" {
     run get_field '{"slug":"alpha","boot":"auto"}' bashio::app.boot
     [ "${output}" = "auto" ]
@@ -784,6 +795,15 @@ get_field() {
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"ingress_panel":true}' ]
 }
 
+@test "addon.ingress_panel normalizes the value and cannot inject extra options" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::app.ingress_panel "alpha" 'true,"rootfs_path":"/"'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/body")" = '{"ingress_panel":false}' ]
+    run jq -e 'has("rootfs_path")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
 @test "addon.watchdog reads the value when no second argument is given" {
     run get_field '{"slug":"alpha","watchdog":true}' bashio::app.watchdog
     [ "${output}" = "true" ]
@@ -794,6 +814,15 @@ get_field() {
     run bashio::app.watchdog "alpha" "false"
     [ "${status}" -eq 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /addons/alpha/options {"watchdog":false}' ]
+}
+
+@test "addon.watchdog normalizes the value and cannot inject extra options" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::app.watchdog "alpha" 'true,"rootfs_path":"/"'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/body")" = '{"watchdog":false}' ]
+    run jq -e 'has("rootfs_path")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
 }
 
 @test "addon.watchdog propagates an API failure on set" {

--- a/tests/audio.bats
+++ b/tests/audio.bats
@@ -31,6 +31,20 @@ setup() {
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/update {"version":"1.2.3"}' ]
 }
 
+@test "audio.update propagates an API failure with a version" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.update "1.2.3" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "audio.update propagates an API failure without a version" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.update || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
 # ------------------------------------------------------------------------------
 # bashio::audio.reload (preserved + expanded)
 # ------------------------------------------------------------------------------

--- a/tests/backups.bats
+++ b/tests/backups.bats
@@ -86,6 +86,20 @@ setup() {
     [ ! -e "${BATS_TEST_TMPDIR}/call" ]
 }
 
+@test "backups.freeze rejecting a value does not inject control characters into the log" {
+    # The rejected value is untrusted; a newline or escape sequence in it must
+    # not reach the log verbatim. Call directly (not via run) so the stub's
+    # captured message survives.
+    logged=""
+    bashio::log.error() { logged="$*"; }
+    rc=0
+    bashio::backups.freeze "$(printf '1\nESC\x1bINJECT')" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ -n "${logged}" ]
+    [[ "${logged}" != *$'\n'* ]]
+    [[ "${logged}" != *$'\x1b'* ]]
+}
+
 # ------------------------------------------------------------------------------
 # backups.thaw
 # ------------------------------------------------------------------------------

--- a/tests/backups.bats
+++ b/tests/backups.bats
@@ -62,6 +62,14 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "backups.freeze rejects a non-integer timeout without calling the API" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::backups.freeze '30,"foo":1' || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
 # ------------------------------------------------------------------------------
 # backups.thaw
 # ------------------------------------------------------------------------------
@@ -107,6 +115,14 @@ setup() {
     rc=0
     bashio::backups.days_until_stale "10" || rc=$?
     [ "${rc}" -ne 0 ]
+}
+
+@test "backups.days_until_stale rejects a non-integer value without calling the API" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::backups.days_until_stale '10,"foo":1' || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
 }
 
 # ------------------------------------------------------------------------------

--- a/tests/backups.bats
+++ b/tests/backups.bats
@@ -70,6 +70,22 @@ setup() {
     [ ! -e "${BATS_TEST_TMPDIR}/call" ]
 }
 
+@test "backups.freeze accepts a zero timeout" {
+    bashio::api.supervisor() { printf '%s\n' "$@" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::backups.freeze "0"
+    [ "${status}" -eq 0 ]
+    [ "$(sed -n '3p' "${BATS_TEST_TMPDIR}/call")" = '{"timeout":0}' ]
+}
+
+@test "backups.freeze rejects a leading-zero timeout without calling the API" {
+    # A leading zero (e.g. "007") would embed as invalid JSON, so reject it.
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::backups.freeze "007" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
 # ------------------------------------------------------------------------------
 # backups.thaw
 # ------------------------------------------------------------------------------
@@ -121,6 +137,21 @@ setup() {
     bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
     rc=0
     bashio::backups.days_until_stale '10,"foo":1' || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "backups.days_until_stale accepts a zero value" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::backups.days_until_stale "0"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /backups/options {"days_until_stale":0}' ]
+}
+
+@test "backups.days_until_stale rejects a leading-zero value without calling the API" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::backups.days_until_stale "007" || rc=$?
     [ "${rc}" -ne 0 ]
     [ ! -e "${BATS_TEST_TMPDIR}/call" ]
 }

--- a/tests/core.bats
+++ b/tests/core.bats
@@ -321,6 +321,15 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "core.watchdog normalizes the value and cannot inject extra options" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::core.watchdog 'true,"backups_exclude_database":true'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/body")" = '{"watchdog":false}' ]
+    run jq -e 'has("backups_exclude_database")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
 # ------------------------------------------------------------------------------
 # core.stats: fetcher, filtering, caching, and failure handling.
 # ------------------------------------------------------------------------------

--- a/tests/discovery.bats
+++ b/tests/discovery.bats
@@ -48,6 +48,17 @@ setup() {
     [ "$(printf '%s' "${payload}" | jq -r '.service')" = "myservice" ]
 }
 
+@test "discovery does not log the config payload" {
+    # The configuration object can carry credentials (for example MQTT broker
+    # username and password), so it must not reach the trace log.
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { printf '%s' 'test-uuid'; }
+    bashio::discovery "mqtt" '{"username":"admin","password":"hunter2"}' >/dev/null
+    [[ "${logged}" != *"hunter2"* ]]
+    [[ "${logged}" != *"admin"* ]]
+}
+
 @test "discovery payload embeds the config object" {
     bashio::api.supervisor() {
         printf '%s' "$3" >"${BATS_TEST_TMPDIR}/payload"

--- a/tests/mounts.bats
+++ b/tests/mounts.bats
@@ -146,6 +146,17 @@ setup() {
     [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
 }
 
+@test "mounts.create does not log the mount credentials" {
+    # A CIFS/NFS mount definition carries a username and password; these must
+    # not reach the trace log.
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { return 0; }
+    bashio::mounts.create '{"name":"share","username":"admin","password":"hunter2"}'
+    [[ "${logged}" != *"hunter2"* ]]
+    [[ "${logged}" != *"admin"* ]]
+}
+
 # ---------------------------------------------------------------------------
 # bashio::mounts.options
 # ---------------------------------------------------------------------------
@@ -181,6 +192,16 @@ setup() {
     [ "${status}" -ne 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /mounts/options {"default_backup_mount":"x"}' ]
     [ -f "${__BASHIO_CACHE_DIR}/mounts.info.cache" ]
+}
+
+@test "mounts.options does not log the options payload" {
+    # The options object can carry mount credentials, so the payload must not
+    # reach the trace log.
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { return 0; }
+    bashio::mounts.options '{"name":"share","password":"hunter2"}'
+    [[ "${logged}" != *"hunter2"* ]]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/network.bats
+++ b/tests/network.bats
@@ -254,6 +254,15 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "network.enabled normalizes the value and cannot inject extra options" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::network.enabled 'eth0' 'true,"ipv4":{"method":"disabled"}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/body")" = '{"enabled":false}' ]
+    run jq -e 'has("ipv4")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
 @test "network.enabled getter propagates an API failure" {
     bashio::api.supervisor() { return 1; }
     run bashio::network.enabled


### PR DESCRIPTION
# Proposed Changes

Wave A of the whole-project review: three confirmed bugs plus the
matching tests.

- **`audio.update` swallowed API failures.** Both `POST /audio/update`
  branches lacked the `|| return "${__BASHIO_EXIT_NOK}"` guard that every
  sibling update helper uses, so the function returned the status of
  `cache.flush_all` and flushed regardless of whether the update succeeded.
- **JSON injection via unnormalised raw-`^` setters.** `app.auto_update`,
  `app.ingress_panel`, `app.watchdog`, `core.watchdog` and `network.enabled`
  interpolated the caller value straight into the POST body, so a value like
  `true,"rootfs_path":"/"` injected extra option keys (the class already
  fixed in `security.sh`). Booleans now normalise to a literal `true`/`false`;
  `backups.freeze` and `backups.days_until_stale` validate a non-negative integer.
- **Credentials traced at trace level.** `mounts.create`, `mounts.options`
  and `discovery` logged their full payload; mount definitions carry CIFS/NFS
  credentials and discovery configs carry broker credentials. They now trace
  only the function name (and the service slug for discovery), matching `auth`
  and `ingress`.

Adds injection, propagation, validation and no-leak tests for each case.
Full suite green (1119 tests), shellcheck and shfmt clean.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for audio updates.
  * Added validation for backup timeout/retention inputs.
  * Enhanced boolean option normalization across setters to prevent configuration injection.

* **Security**
  * Reduced sensitive-data exposure by stopping payload/credential logging in discovery and mounts.
  * Ensured normalized inputs cannot inject extra fields into API requests.

* **Tests**
  * Added tests for injection prevention, input validation, error propagation, and logging redaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->