### PR TITLE
Stop fetchers from overwriting the base info blob with a filtered result

### DIFF
--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -93,7 +93,12 @@ function bashio::audio() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'audio.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -171,7 +176,12 @@ function bashio::audio.stats() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'audio.stats' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -98,7 +98,7 @@ function bashio::audio() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'audio.info' ]]; then
@@ -186,7 +186,7 @@ function bashio::audio.stats() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'audio.stats' ]]; then

--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -69,8 +69,13 @@ function bashio::audio() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'audio.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'audio.info'; then
@@ -152,8 +157,13 @@ function bashio::audio.stats() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'audio.stats' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'audio.stats'; then

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -72,7 +72,7 @@ function bashio::cli() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'cli.info' ]]; then
@@ -152,7 +152,7 @@ function bashio::cli.stats() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'cli.stats' ]]; then

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -43,8 +43,13 @@ function bashio::cli() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'cli.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'cli.info'; then
@@ -118,8 +123,13 @@ function bashio::cli.stats() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'cli.stats' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'cli.stats'; then

--- a/lib/cli.sh
+++ b/lib/cli.sh
@@ -67,7 +67,12 @@ function bashio::cli() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'cli.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -137,7 +142,12 @@ function bashio::cli.stats() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'cli.stats' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -91,8 +91,13 @@ function bashio::core() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'core.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'core.info'; then
@@ -258,8 +263,13 @@ function bashio::core.stats() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'core.stats' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'core.stats'; then

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -120,7 +120,7 @@ function bashio::core() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'core.info' ]]; then
@@ -292,7 +292,7 @@ function bashio::core.stats() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'core.stats' ]]; then

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -115,7 +115,12 @@ function bashio::core() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'core.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -277,7 +282,12 @@ function bashio::core.stats() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'core.stats' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -98,7 +98,7 @@ function bashio::dns() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'dns.info' ]]; then
@@ -202,7 +202,7 @@ function bashio::dns.stats() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'dns.stats' ]]; then

--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -69,8 +69,13 @@ function bashio::dns() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'dns.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'dns.info'; then
@@ -168,8 +173,13 @@ function bashio::dns.stats() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'dns.stats' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'dns.stats'; then

--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -93,7 +93,12 @@ function bashio::dns() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'dns.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -187,7 +192,12 @@ function bashio::dns.stats() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'dns.stats' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -23,8 +23,13 @@ function bashio::docker() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'docker.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'docker.info'; then
@@ -130,8 +135,13 @@ function bashio::docker.registries() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'docker.registries' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'docker.registries'; then

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -47,7 +47,12 @@ function bashio::docker() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'docker.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -149,7 +154,12 @@ function bashio::docker.registries() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'docker.registries' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -52,7 +52,7 @@ function bashio::docker() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'docker.info' ]]; then
@@ -164,7 +164,7 @@ function bashio::docker.registries() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'docker.registries' ]]; then

--- a/lib/hardware.sh
+++ b/lib/hardware.sh
@@ -52,7 +52,7 @@ function bashio::hardware() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'hardware.info' ]]; then

--- a/lib/hardware.sh
+++ b/lib/hardware.sh
@@ -47,7 +47,12 @@ function bashio::hardware() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'hardware.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/hardware.sh
+++ b/lib/hardware.sh
@@ -23,8 +23,13 @@ function bashio::hardware() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'hardware.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'hardware.info'; then

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -84,7 +84,7 @@ function bashio::host() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'host.info' ]]; then

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -79,7 +79,12 @@ function bashio::host() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'host.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/host.sh
+++ b/lib/host.sh
@@ -55,8 +55,13 @@ function bashio::host() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'host.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'host.info'; then

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -47,7 +47,12 @@ function bashio::info() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -23,8 +23,13 @@ function bashio::info() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'info'; then

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -52,7 +52,7 @@ function bashio::info() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'info' ]]; then

--- a/lib/ingress.sh
+++ b/lib/ingress.sh
@@ -23,8 +23,13 @@ function bashio::ingress.panels() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'ingress.panels' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'ingress.panels'; then

--- a/lib/ingress.sh
+++ b/lib/ingress.sh
@@ -52,7 +52,7 @@ function bashio::ingress.panels() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'ingress.panels' ]]; then

--- a/lib/ingress.sh
+++ b/lib/ingress.sh
@@ -47,7 +47,12 @@ function bashio::ingress.panels() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'ingress.panels' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/mounts.sh
+++ b/lib/mounts.sh
@@ -23,8 +23,13 @@ function bashio::mounts() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'mounts.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'mounts.info'; then

--- a/lib/mounts.sh
+++ b/lib/mounts.sh
@@ -52,7 +52,7 @@ function bashio::mounts() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'mounts.info' ]]; then

--- a/lib/mounts.sh
+++ b/lib/mounts.sh
@@ -47,7 +47,12 @@ function bashio::mounts() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'mounts.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/multicast.sh
+++ b/lib/multicast.sh
@@ -84,7 +84,12 @@ function bashio::multicast() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'multicast.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -154,7 +159,12 @@ function bashio::multicast.stats() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'multicast.stats' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/multicast.sh
+++ b/lib/multicast.sh
@@ -89,7 +89,7 @@ function bashio::multicast() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'multicast.info' ]]; then
@@ -169,7 +169,7 @@ function bashio::multicast.stats() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'multicast.stats' ]]; then

--- a/lib/multicast.sh
+++ b/lib/multicast.sh
@@ -60,8 +60,13 @@ function bashio::multicast() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'multicast.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'multicast.info'; then
@@ -135,8 +140,13 @@ function bashio::multicast.stats() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'multicast.stats' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'multicast.stats'; then

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -62,7 +62,7 @@ function bashio::network() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'network.info' ]]; then
@@ -144,7 +144,7 @@ function bashio::network.interface() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != "network.interface.${interface}.info" ]]; then

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -57,7 +57,12 @@ function bashio::network() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'network.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -129,7 +134,12 @@ function bashio::network.interface() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != "network.interface.${interface}.info" ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/network.sh
+++ b/lib/network.sh
@@ -33,8 +33,13 @@ function bashio::network() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'network.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'network.info'; then
@@ -110,8 +115,13 @@ function bashio::network.interface() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != "network.interface.${interface}.info" ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists "network.interface.${interface}.info"; then

--- a/lib/observer.sh
+++ b/lib/observer.sh
@@ -43,8 +43,13 @@ function bashio::observer() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'observer.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'observer.info'; then
@@ -126,8 +131,13 @@ function bashio::observer.stats() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'observer.stats' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'observer.stats'; then

--- a/lib/observer.sh
+++ b/lib/observer.sh
@@ -67,7 +67,12 @@ function bashio::observer() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'observer.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -145,7 +150,12 @@ function bashio::observer.stats() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'observer.stats' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/observer.sh
+++ b/lib/observer.sh
@@ -72,7 +72,7 @@ function bashio::observer() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'observer.info' ]]; then
@@ -160,7 +160,7 @@ function bashio::observer.stats() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'observer.stats' ]]; then

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -75,7 +75,12 @@ function bashio::os() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'os.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -51,8 +51,13 @@ function bashio::os() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'os.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'os.info'; then

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -80,7 +80,7 @@ function bashio::os() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'os.info' ]]; then

--- a/lib/resolution.sh
+++ b/lib/resolution.sh
@@ -52,7 +52,7 @@ function bashio::resolution() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'resolution.info' ]]; then

--- a/lib/resolution.sh
+++ b/lib/resolution.sh
@@ -47,7 +47,12 @@ function bashio::resolution() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'resolution.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/resolution.sh
+++ b/lib/resolution.sh
@@ -23,8 +23,13 @@ function bashio::resolution() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'resolution.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'resolution.info'; then

--- a/lib/security.sh
+++ b/lib/security.sh
@@ -47,7 +47,12 @@ function bashio::security() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'security.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/security.sh
+++ b/lib/security.sh
@@ -23,8 +23,13 @@ function bashio::security() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'security.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'security.info'; then

--- a/lib/security.sh
+++ b/lib/security.sh
@@ -52,7 +52,7 @@ function bashio::security() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'security.info' ]]; then

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -94,8 +94,13 @@ function bashio::supervisor() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'supervisor.info' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'supervisor.info'; then
@@ -417,8 +422,13 @@ function bashio::supervisor.stats() {
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
     if bashio::cache.exists "${cache_key}"; then
-        bashio::cache.get "${cache_key}"
-        return "${__BASHIO_EXIT_OK}"
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'supervisor.stats' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
     fi
 
     if bashio::cache.exists 'supervisor.stats'; then

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -118,7 +118,12 @@ function bashio::supervisor() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'supervisor.info' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"
@@ -436,7 +441,12 @@ function bashio::supervisor.stats() {
         fi
     fi
 
-    bashio::cache.set "${cache_key}" "${response}"
+    # Never overwrite the base info blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'supervisor.stats' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
     printf "%s" "${response}"
 
     return "${__BASHIO_EXIT_OK}"

--- a/lib/supervisor.sh
+++ b/lib/supervisor.sh
@@ -123,7 +123,7 @@ function bashio::supervisor() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'supervisor.info' ]]; then
@@ -451,7 +451,7 @@ function bashio::supervisor.stats() {
         fi
     fi
 
-    # Never overwrite the base info blob with a filtered result: the
+    # Never overwrite the base blob with a filtered result: the
     # base blob is already cached above, so only cache under a distinct
     # caller-provided key.
     if [[ "${cache_key}" != 'supervisor.stats' ]]; then

--- a/tests/dns.bats
+++ b/tests/dns.bats
@@ -143,6 +143,19 @@ setup() {
     [ "$(printf '%s' "${output}" | jq -r '.host')" = "172.30.32.3" ]
 }
 
+@test "dns base key with a filter stays filtered on a repeated call" {
+    # The base blob is cached after the first call; a second base-key+filter
+    # call must still apply the filter, not return the cached unfiltered blob.
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"1.0","host":"172.30.32.3"}'
+    }
+    run bashio::dns 'dns.info' '.host'
+    [ "${output}" = "172.30.32.3" ]
+    run bashio::dns 'dns.info' '.host'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "172.30.32.3" ]
+}
+
 @test "dns serves a previously cached value without calling the API" {
     bashio::cache.set 'dns.info.cached' 'cached-value'
     bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }

--- a/tests/dns.bats
+++ b/tests/dns.bats
@@ -128,6 +128,21 @@ setup() {
     [ "${status}" -ne 0 ]
 }
 
+@test "dns with the base key and a filter does not corrupt the base blob" {
+    # Passing the reserved base key together with a filter must not overwrite
+    # the shared blob with the filtered scalar; later unfiltered reads must
+    # still return the full object.
+    bashio::api.supervisor() {
+        printf '%s' '{"version":"1.0","host":"172.30.32.3"}'
+    }
+    run bashio::dns 'dns.info' '.host'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "172.30.32.3" ]
+    run bashio::cache.get 'dns.info'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.host')" = "172.30.32.3" ]
+}
+
 @test "dns serves a previously cached value without calling the API" {
     bashio::cache.set 'dns.info.cached' 'cached-value'
     bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }

--- a/tests/dns.bats
+++ b/tests/dns.bats
@@ -150,6 +150,7 @@ setup() {
         printf '%s' '{"version":"1.0","host":"172.30.32.3"}'
     }
     run bashio::dns 'dns.info' '.host'
+    [ "${status}" -eq 0 ]
     [ "${output}" = "172.30.32.3" ]
     run bashio::dns 'dns.info' '.host'
     [ "${status}" -eq 0 ]

--- a/tests/network.bats
+++ b/tests/network.bats
@@ -154,6 +154,20 @@ setup() {
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /network/interface/eth0/info false" ]
 }
 
+@test "network.interface with the dynamic base key and a filter does not corrupt the base blob" {
+    # The per-interface base key is dynamic; passing it together with a filter
+    # must not overwrite the shared blob with the filtered scalar.
+    bashio::api.supervisor() {
+        printf '%s' '{"interface":"eth0","type":"ethernet"}'
+    }
+    run bashio::network.interface 'network.interface.eth0.info' 'eth0' '.type'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "ethernet" ]
+    run bashio::cache.get 'network.interface.eth0.info'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.interface')" = "eth0" ]
+}
+
 @test "network.interface applies a jq filter to the info response" {
     bashio::api.supervisor() {
         printf '%s' '{"interface":"eth0","type":"ethernet"}'

--- a/tests/network.bats
+++ b/tests/network.bats
@@ -166,6 +166,11 @@ setup() {
     run bashio::cache.get 'network.interface.eth0.info'
     [ "${status}" -eq 0 ]
     [ "$(printf '%s' "${output}" | jq -r '.interface')" = "eth0" ]
+    # A repeated base-key+filter call must still apply the filter, not return
+    # the cached unfiltered blob.
+    run bashio::network.interface 'network.interface.eth0.info' 'eth0' '.type'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "ethernet" ]
 }
 
 @test "network.interface applies a jq filter to the info response" {


### PR DESCRIPTION
# Proposed Changes

Wave B of the whole-project review: closes a latent cache-corruption footgun
shared by every cached info/stats fetcher.

Each fetcher ended with `bashio::cache.set "${cache_key}" "${response}"`, where
the default cache key is the reserved base blob key (for example `dns.info`).
Calling a fetcher with that base key together with a jq filter replaced the
shared blob with the filtered scalar, so later unfiltered reads returned
corrupted data. This is the generalised form of the bug previously fixed in
`lib/mounts.sh` (which had a non-empty default filter that triggered it on a
bare call).

The final write in all 26 fetchers now only caches under a distinct
caller-provided key, never the base key. The base blob is already cached
separately earlier in each function, so nothing is lost, and the existing
getters (which pass distinct keys) are unaffected. `network.interface` guards
against its dynamic per-interface base key.

Adds regression tests for the canonical case (`dns`) and the dynamic-base case
(`network.interface`); the existing `mounts` regression test continues to cover
that module. Full suite green (1126 tests), shellcheck and shfmt clean.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented filtered queries from returning or overwriting unfiltered base cache entries; filtered results are recomputed or stored only under distinct caller-provided keys, preserving base cached data.

* **Tests**
  * Added Bats tests verifying filtered requests return expected outputs and do not modify the original base cache entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->