### PR TITLE
Strengthen weak test assertions (pwned boundary, filtered arrays, var)

### DIFF
--- a/tests/backups.bats
+++ b/tests/backups.bats
@@ -345,7 +345,9 @@ setup() {
     bashio::api.supervisor() { printf '%s' '{"addons":[{"slug":"core_ssh"}]}'; }
     run bashio::backup.addons "aaa"
     [ "${status}" -eq 0 ]
-    [[ "${output}" == *"core_ssh"* ]]
+    # Must return the inner array, not the full unfiltered object. A substring
+    # check would also pass on the wrapping blob, so pin the exact structure.
+    [ "$(printf '%s' "${output}" | jq -cS '.')" = '[{"slug":"core_ssh"}]' ]
 }
 
 @test "backup.addons returns empty when the addon list is empty" {
@@ -359,7 +361,7 @@ setup() {
     bashio::api.supervisor() { printf '%s' '{"repositories":["core"]}'; }
     run bashio::backup.repositories "aaa"
     [ "${status}" -eq 0 ]
-    [[ "${output}" == *"core"* ]]
+    [ "$(printf '%s' "${output}" | jq -cS '.')" = '["core"]' ]
 }
 
 @test "backup.repositories returns empty when the list is empty" {
@@ -373,7 +375,7 @@ setup() {
     bashio::api.supervisor() { printf '%s' '{"folders":["share"]}'; }
     run bashio::backup.folders "aaa"
     [ "${status}" -eq 0 ]
-    [[ "${output}" == *"share"* ]]
+    [ "$(printf '%s' "${output}" | jq -cS '.')" = '["share"]' ]
 }
 
 @test "backup.folders returns empty when the list is empty" {

--- a/tests/pwned.bats
+++ b/tests/pwned.bats
@@ -45,6 +45,24 @@ setup() {
     [[ "${output}" != *"SuperSecretValue"* ]]
 }
 
+@test "pwned sends only the 5-char hash prefix to the HIBP API (k-anonymity)" {
+    # The whole point of the k-anonymity model is that only the first 5 hash
+    # characters ever leave the machine; the full SHA-1 (and its suffix) must
+    # never be sent. Capture what is actually passed to curl and assert it.
+    local captured="${BATS_TEST_TMPDIR}/curl_args"
+    curl() {
+        printf '%s' "$*" >"${captured}"
+        printf '%s\n%s' "${MOCK_BODY}" "${MOCK_STATUS}"
+    }
+    bashio::pwned "test" >/dev/null
+    run cat "${captured}"
+    # The 5-char prefix is sent...
+    [[ "${output}" == *"/A94A8"* ]]
+    # ...but never the full hash or the matching suffix.
+    [[ "${output}" != *"A94A8FE5CCB19BA61C4C0873D391E987982FBBD3"* ]]
+    [[ "${output}" != *"${TEST_SUFFIX}"* ]]
+}
+
 @test "pwned returns the occurrence count when the password is found" {
     MOCK_BODY="${TEST_SUFFIX}:42"
     run bashio::pwned "test"

--- a/tests/pwned.bats
+++ b/tests/pwned.bats
@@ -51,7 +51,8 @@ setup() {
     # never be sent. Capture what is actually passed to curl and assert it.
     local captured="${BATS_TEST_TMPDIR}/curl_args"
     curl() {
-        printf '%s' "$*" >"${captured}"
+        # Capture each argument on its own line so boundaries are preserved.
+        printf '%s\n' "$@" >"${captured}"
         printf '%s\n%s' "${MOCK_BODY}" "${MOCK_STATUS}"
     }
     bashio::pwned "test" >/dev/null

--- a/tests/var.bats
+++ b/tests/var.bats
@@ -20,6 +20,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
     [ "${status}" -eq 0 ]
 }
 
+@test "bashio::var.false fails for any other value" {
+    run bashio::var.false "true"
+    [ "${status}" -ne 0 ]
+}
+
 @test "bashio::var.has_value succeeds for a non-empty value" {
     run bashio::var.has_value "something"
     [ "${status}" -eq 0 ]
@@ -33,6 +38,11 @@ source "${BATS_TEST_DIRNAME}/test_helper.bash"
 @test "bashio::var.is_empty succeeds for an empty value" {
     run bashio::var.is_empty ""
     [ "${status}" -eq 0 ]
+}
+
+@test "bashio::var.is_empty fails for a non-empty value" {
+    run bashio::var.is_empty "something"
+    [ "${status}" -ne 0 ]
 }
 
 @test "bashio::var.equals succeeds for equal values" {


### PR DESCRIPTION
# Proposed Changes

Wave C of the whole-project review: strengthens three tests that passed
regardless of the regressions they were meant to catch. Each new or changed
assertion was verified to fail against a simulated regression (mutation test).

- **`pwned` k-anonymity boundary.** The tests only asserted on the log, never
  on what was actually sent to the network. A regression sending the full
  SHA-1 (rather than the 5-char prefix) to the HIBP API would not be caught.
  Added a test that captures the `curl` arguments and asserts the prefix is
  sent while the full hash and its suffix are not.
- **`backup.addons` / `repositories` / `folders`.** These asserted the filtered
  output with a substring match, which also passes on the full unfiltered
  object blob. Pinned the exact array structure instead (normalised with `jq`).
- **`var.false` / `var.is_empty`.** Only the success direction was tested; a
  regression making either always succeed would pass. Added the
  failing-direction tests.

Full suite green (1130 tests), shfmt clean.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved backup test validation to verify exact JSON structure integrity
  * Added security verification test to ensure API calls transmit minimal required data
  * Added validation tests for variable function edge cases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->