### PR TITLE
Tidy consistency and documentation rough edges

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ bashio::log.info "${USERNAME}"
 
 ## Functions
 
-Bashio has more than 250 functions available: communicating with
+Bashio has more than 450 functions available: communicating with
 the Supervisor API, Have I Been Pwned, file system, logging, configuration handling
 and a lot more!
 

--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -17,9 +17,6 @@ shopt -s inherit_errexit 2>/dev/null || true # Command substitution inherits the
 # GLOBALS
 # ==============================================================================
 
-# Bashio version number
-readonly BASHIO_VERSION="0.1.0"
-
 # Stores the location of this library
 readonly __BASHIO_LIB_DIR=$(dirname "${BASH_SOURCE[0]}")
 

--- a/lib/docker.sh
+++ b/lib/docker.sh
@@ -206,12 +206,12 @@ function bashio::docker.registries.add() {
 }
 
 # ------------------------------------------------------------------------------
-# Removes a Docker registry.
+# Deletes a Docker registry.
 #
 # Arguments:
 #   $1 Hostname of the registry
 # ------------------------------------------------------------------------------
-function bashio::docker.registries.remove() {
+function bashio::docker.registries.delete() {
     local hostname=${1}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"

--- a/lib/os.sh
+++ b/lib/os.sh
@@ -36,7 +36,8 @@ function bashio::os.config_sync() {
 }
 
 # ------------------------------------------------------------------------------
-# Returns a JSON object with generic Home Assistant information.
+# Returns a JSON object with generic Home Assistant Operating System
+# (HassOS) information.
 #
 # Arguments:
 #   $1 Cache key to store results in (optional)

--- a/tests/docker.bats
+++ b/tests/docker.bats
@@ -275,17 +275,17 @@ setup() {
 }
 
 # ------------------------------------------------------------------------------
-# bashio::docker.registries.remove
+# bashio::docker.registries.delete
 # ------------------------------------------------------------------------------
 
-@test "docker.registries.remove deletes the registry by hostname" {
+@test "docker.registries.delete deletes the registry by hostname" {
     bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"; }
-    run bashio::docker.registries.remove "hub.docker.com"
+    run bashio::docker.registries.delete "hub.docker.com"
     [ "${status}" -eq 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /docker/registries/hub.docker.com" ]
 }
 
-@test "docker.registries.remove flushes the cache" {
+@test "docker.registries.delete flushes the cache" {
     # Prime the cache first.
     bashio::api.supervisor() {
         printf '%s' '{"registries":{"hub.docker.com":{"username":"alice"}}}'
@@ -294,16 +294,16 @@ setup() {
     [ -f "${__BASHIO_CACHE_DIR}/docker.registries.cache" ]
 
     bashio::api.supervisor() { printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call2"; }
-    bashio::docker.registries.remove "hub.docker.com"
+    bashio::docker.registries.delete "hub.docker.com"
     [ ! -d "${__BASHIO_CACHE_DIR}" ]
 }
 
-@test "docker.registries.remove propagates an API failure" {
+@test "docker.registries.delete propagates an API failure" {
     bashio::api.supervisor() {
         printf '%s' "$*" >"${BATS_TEST_TMPDIR}/call"
         return 1
     }
-    run bashio::docker.registries.remove "hub.docker.com"
+    run bashio::docker.registries.delete "hub.docker.com"
     [ "${status}" -ne 0 ]
     [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "DELETE /docker/registries/hub.docker.com" ]
 }


### PR DESCRIPTION
# Proposed Changes

Wave D of the whole-project review: small consistency and documentation
cleanups.

- **Rename `docker.registries.remove` to `docker.registries.delete`** so it
  matches every other deletion helper in the library (`repository.delete`,
  `mount.delete`, `backup.delete`, `job.delete`, `services.delete`,
  `discovery.delete`). The function has not been in a release yet, so no
  deprecated alias is needed.
- **Fix the `bashio::os` docstring.** It was copy-pasted from `bashio::core`
  and claimed to return "generic Home Assistant information"; it actually
  returns Home Assistant Operating System (HassOS) information.
- **Remove the dead `BASHIO_VERSION` constant.** It was stuck at `0.1.0` while
  releases are at v0.17.x, and nothing in the library, tests, or CI read it.
- **Update the README function count** from "more than 250" to "more than 450"
  (the library now defines 484 functions).

Full suite green (1130 tests); shellcheck, shfmt and codespell clean.

(Note: the fifth review item, the `actions/upload-code-coverage` CI step, was
checked and is working - it succeeds on completed runs and the coverage bot
posts on PRs - so no change was needed there.)

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated library documentation to reflect 450+ functions (increased from 250+)
  * Refined HassOS information terminology

* **Refactor**
  * Renamed Docker registry management function for consistency
  * Removed library version constant from global scope

* **Tests**
  * Updated test suite to align with refactored function naming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->