### PR TITLE
Add bashio::dns.options to set DNS plugin options

### DIFF
--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -54,7 +54,9 @@ function bashio::dns.restart() {
 function bashio::dns.options() {
     local options=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    # The options object is an opaque caller-provided payload, so trace only
+    # the function name, never the payload itself.
+    bashio::log.trace "${FUNCNAME[0]}"
 
     bashio::api.supervisor POST /dns/options "${options}" ||
         return "${__BASHIO_EXIT_NOK}"

--- a/lib/dns.sh
+++ b/lib/dns.sh
@@ -46,6 +46,22 @@ function bashio::dns.restart() {
 }
 
 # ------------------------------------------------------------------------------
+# Sets the DNS plugin options.
+#
+# Arguments:
+#   $1 Options object (JSON)
+# ------------------------------------------------------------------------------
+function bashio::dns.options() {
+    local options=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST /dns/options "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
 # Returns the logs created by the DNS.
 # ------------------------------------------------------------------------------
 function bashio::dns.logs() {

--- a/tests/dns.bats
+++ b/tests/dns.bats
@@ -82,6 +82,24 @@ setup() {
 }
 
 # ------------------------------------------------------------------------------
+# bashio::dns.options
+# ------------------------------------------------------------------------------
+
+@test "dns.options posts the given JSON to the options endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::dns.options '{"fallback":false}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /dns/options {"fallback":false}' ]
+}
+
+@test "dns.options propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::dns.options '{"fallback":false}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
 # bashio::dns.logs
 # ------------------------------------------------------------------------------
 

--- a/tests/dns.bats
+++ b/tests/dns.bats
@@ -99,6 +99,15 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "dns.options flushes the cache after a successful set" {
+    bashio::cache.set 'dns.info' 'stale'
+    bashio::api.supervisor() { return 0; }
+    run bashio::dns.options '{"fallback":false}'
+    [ "${status}" -eq 0 ]
+    run bashio::cache.exists 'dns.info'
+    [ "${status}" -ne 0 ]
+}
+
 # ------------------------------------------------------------------------------
 # bashio::dns.logs
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Proposed Changes

Adds `bashio::dns.options`, a setter for `POST /dns/options` that accepts a
JSON options object (`servers`, `fallback`), matching the generic
options-setter idiom already used by `security.options`, `docker.options` and
`mounts.options`. The endpoint and body shape were verified against the
Supervisor source (`supervisor/api/dns.py`).

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DNS plugin options can now be configured through Supervisor integration, allowing users to set DNS parameters with automatic cache refresh to maintain system consistency.

* **Tests**
  * Added test coverage for DNS configuration options, validating successful API calls and error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->