### PR TITLE
Add bashio::jobs.options to set job manager options

### DIFF
--- a/lib/jobs.sh
+++ b/lib/jobs.sh
@@ -25,7 +25,9 @@ function bashio::jobs.reset() {
 function bashio::jobs.options() {
     local options=${1}
 
-    bashio::log.trace "${FUNCNAME[0]}" "$@"
+    # The options object is an opaque caller-provided payload, so trace only
+    # the function name, never the payload itself.
+    bashio::log.trace "${FUNCNAME[0]}"
 
     bashio::api.supervisor POST /jobs/options "${options}" ||
         return "${__BASHIO_EXIT_NOK}"

--- a/lib/jobs.sh
+++ b/lib/jobs.sh
@@ -17,6 +17,22 @@ function bashio::jobs.reset() {
 }
 
 # ------------------------------------------------------------------------------
+# Sets the job manager options.
+#
+# Arguments:
+#   $1 Options object (JSON)
+# ------------------------------------------------------------------------------
+function bashio::jobs.options() {
+    local options=${1}
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    bashio::api.supervisor POST /jobs/options "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
 # Returns a JSON object with information about jobs.
 #
 # Arguments:

--- a/tests/jobs.bats
+++ b/tests/jobs.bats
@@ -51,6 +51,15 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "jobs.options flushes the cache after a successful set" {
+    bashio::cache.set 'some.key' 'stale'
+    bashio::api.supervisor() { return 0; }
+    run bashio::jobs.options '{"ignore_conditions":[]}'
+    [ "${status}" -eq 0 ]
+    run bashio::cache.exists 'some.key'
+    [ "${status}" -ne 0 ]
+}
+
 # ------------------------------------------------------------------------------
 # jobs (the generic fetcher)
 # ------------------------------------------------------------------------------

--- a/tests/jobs.bats
+++ b/tests/jobs.bats
@@ -60,6 +60,17 @@ setup() {
     [ "${status}" -ne 0 ]
 }
 
+@test "jobs.options does not log the options payload" {
+    # The options object is an opaque caller-provided payload, so it must not
+    # reach the trace log. Call directly (not via run) so the captured message
+    # survives.
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { return 0; }
+    bashio::jobs.options '{"ignore_conditions":["SENTINEL_VALUE"]}'
+    [[ "${logged}" != *"SENTINEL_VALUE"* ]]
+}
+
 # ------------------------------------------------------------------------------
 # jobs (the generic fetcher)
 # ------------------------------------------------------------------------------

--- a/tests/jobs.bats
+++ b/tests/jobs.bats
@@ -34,6 +34,24 @@ setup() {
 }
 
 # ------------------------------------------------------------------------------
+# bashio::jobs.options
+# ------------------------------------------------------------------------------
+
+@test "jobs.options posts the given JSON to the options endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::jobs.options '{"ignore_conditions":["healthy"]}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /jobs/options {"ignore_conditions":["healthy"]}' ]
+}
+
+@test "jobs.options propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::jobs.options '{"ignore_conditions":[]}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
 # jobs (the generic fetcher)
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Proposed Changes

Adds `bashio::jobs.options`, a setter for `POST /jobs/options` that accepts a
JSON options object (`ignore_conditions`), matching the generic options-setter
idiom already used by `security.options`, `docker.options` and `mounts.options`.
The endpoint and body shape were verified against the Supervisor source
(`supervisor/api/jobs.py`).

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added job options management functionality for submitting configuration payloads to the job service, with automatic cache invalidation on success.

* **Tests**
  * Added test coverage for the new feature, validating payload delivery, error handling, cache behavior, and logging security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->