### PR TITLE
Add bashio::hardware.audio fetcher

### DIFF
--- a/lib/hardware.sh
+++ b/lib/hardware.sh
@@ -64,6 +64,63 @@ function bashio::hardware() {
 }
 
 # ------------------------------------------------------------------------------
+# Returns a JSON object with the audio devices (PulseAudio) known to the
+# system.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::hardware.audio() {
+    local cache_key=${1:-'hardware.audio'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'hardware.audio' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'hardware.audio'; then
+        info=$(bashio::cache.get 'hardware.audio')
+    else
+        info=$(bashio::api.supervisor GET /hardware/audio false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get audio hardware from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'hardware.audio' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'hardware.audio' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
 # Returns a list of available serial devices on the host system.
 # ------------------------------------------------------------------------------
 function bashio::hardware.serial() {

--- a/tests/hardware.bats
+++ b/tests/hardware.bats
@@ -117,6 +117,13 @@ AUDIO_JSON='{"audio":{"input":{"a":"Mic"},"output":{"b":"Speaker"}}}'
     [ "${rc}" -ne 0 ]
 }
 
+@test "hardware.audio propagates a jq filter failure" {
+    bashio::api.supervisor() { printf '%s' "${AUDIO_JSON}"; }
+    rc=0
+    bashio::hardware.audio 'test.bad.filter' 'INVALID_FILTER_!!!' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
 @test "hardware.audio with the base key and a filter does not corrupt the base blob" {
     bashio::api.supervisor() { printf '%s' "${AUDIO_JSON}"; }
     run bashio::hardware.audio 'hardware.audio' '.audio.input.a'

--- a/tests/hardware.bats
+++ b/tests/hardware.bats
@@ -74,6 +74,60 @@ setup() {
 }
 
 # ---------------------------------------------------------------------------
+# bashio::hardware.audio
+# ---------------------------------------------------------------------------
+
+AUDIO_JSON='{"audio":{"input":{"a":"Mic"},"output":{"b":"Speaker"}}}'
+
+@test "hardware.audio calls GET /hardware/audio" {
+    local args_file="${BATS_TEST_TMPDIR}/api_args"
+    bashio::api.supervisor() {
+        printf '%s' "$*" >"${args_file}"
+        printf '%s' "${AUDIO_JSON}"
+    }
+    run bashio::hardware.audio
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "${AUDIO_JSON}" ]
+    [ "$(cat "${args_file}")" = "GET /hardware/audio false" ]
+}
+
+@test "hardware.audio applies an optional jq filter" {
+    bashio::api.supervisor() { printf '%s' "${AUDIO_JSON}"; }
+    run bashio::hardware.audio 'test.audio.input' '.audio.input.a'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "Mic" ]
+}
+
+@test "hardware.audio returns cached data on a second call without hitting the API" {
+    local call_file="${BATS_TEST_TMPDIR}/calls"
+    printf '0' >"${call_file}"
+    bashio::api.supervisor() {
+        printf '%d' $(($(cat "${call_file}") + 1)) >"${call_file}"
+        printf '%s' "${AUDIO_JSON}"
+    }
+    bashio::hardware.audio >/dev/null
+    bashio::hardware.audio >/dev/null
+    [ "$(cat "${call_file}")" -eq 1 ]
+}
+
+@test "hardware.audio propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::hardware.audio || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "hardware.audio with the base key and a filter does not corrupt the base blob" {
+    bashio::api.supervisor() { printf '%s' "${AUDIO_JSON}"; }
+    run bashio::hardware.audio 'hardware.audio' '.audio.input.a'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "Mic" ]
+    run bashio::cache.get 'hardware.audio'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.audio.input.a')" = "Mic" ]
+}
+
+# ---------------------------------------------------------------------------
 # bashio::hardware.serial
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Proposed Changes

Adds `bashio::hardware.audio`, a fetcher for `GET /hardware/audio` that returns
the audio (PulseAudio) devices known to the system. It takes an optional cache
key and jq filter and follows the same fetcher idiom as `bashio::hardware`,
including the guard that prevents a filtered call from overwriting the base
blob. The endpoint was verified against the Supervisor source
(`supervisor/api/hardware.py`).

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added audio hardware detection and querying functionality with fully integrated caching support, optional filtering capabilities, and comprehensive error handling mechanisms.

* **Tests**
  * Added comprehensive test coverage for the audio hardware functionality, including validation of cache behavior consistency, error propagation from upstream API failures, data integrity preservation when filters are applied, proper cache isolation behavior, and edge case handling across multiple operational scenarios and conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->