### PR TITLE
Add bashio::host.services and bashio::host.disk_usage fetchers

### DIFF
--- a/lib/host.sh
+++ b/lib/host.sh
@@ -96,6 +96,118 @@ function bashio::host() {
 }
 
 # ------------------------------------------------------------------------------
+# Returns a JSON object with the systemd services available on the host.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::host.services() {
+    local cache_key=${1:-'host.services'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'host.services' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'host.services'; then
+        info=$(bashio::cache.get 'host.services')
+    else
+        info=$(bashio::api.supervisor GET /host/services false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get host services from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'host.services' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'host.services' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with a breakdown of disk usage on the host system.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::host.disk_usage() {
+    local cache_key=${1:-'host.disk_usage'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'host.disk_usage' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'host.disk_usage'; then
+        info=$(bashio::cache.get 'host.disk_usage')
+    else
+        info=$(bashio::api.supervisor GET /host/disks/default/usage false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get host disk usage from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'host.disk_usage' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'host.disk_usage' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
 # Returns or sets the hostname of the host system.
 #
 # Arguments:

--- a/tests/host.bats
+++ b/tests/host.bats
@@ -131,6 +131,85 @@ setup() {
 }
 
 # ------------------------------------------------------------------------------
+# bashio::host.services
+# ------------------------------------------------------------------------------
+
+@test "host.services calls GET /host/services" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"services":[{"name":"sshd.service","state":"active"}]}'
+    }
+    run bashio::host.services
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /host/services false" ]
+    [ "${output}" = '{"services":[{"name":"sshd.service","state":"active"}]}' ]
+}
+
+@test "host.services applies an optional jq filter" {
+    bashio::api.supervisor() {
+        printf '%s' '{"services":[{"name":"sshd.service","state":"active"}]}'
+    }
+    run bashio::host.services 'host.services.first' '.services[0].name'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "sshd.service" ]
+}
+
+@test "host.services propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::host.services || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "host.services propagates a jq filter failure" {
+    bashio::api.supervisor() { printf '%s' '{"services":[]}'; }
+    rc=0
+    bashio::host.services 'host.services.bad' 'INVALID_FILTER_!!!' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "host.services with the base key and a filter does not corrupt the base blob" {
+    bashio::api.supervisor() {
+        printf '%s' '{"services":[{"name":"sshd.service"}]}'
+    }
+    run bashio::host.services 'host.services' '.services[0].name'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "sshd.service" ]
+    run bashio::cache.get 'host.services'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.services[0].name')" = "sshd.service" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::host.disk_usage
+# ------------------------------------------------------------------------------
+
+@test "host.disk_usage calls GET /host/disks/default/usage" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"total":100,"used":40,"free":60}'
+    }
+    run bashio::host.disk_usage
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /host/disks/default/usage false" ]
+    [ "${output}" = '{"total":100,"used":40,"free":60}' ]
+}
+
+@test "host.disk_usage applies an optional jq filter" {
+    bashio::api.supervisor() { printf '%s' '{"total":100,"used":40,"free":60}'; }
+    run bashio::host.disk_usage 'host.disk_usage.free' '.free'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "60" ]
+}
+
+@test "host.disk_usage propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::host.disk_usage || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
 # hostname getter/setter.
 # ------------------------------------------------------------------------------
 

--- a/tests/host.bats
+++ b/tests/host.bats
@@ -209,6 +209,23 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "host.disk_usage propagates a jq filter failure" {
+    bashio::api.supervisor() { printf '%s' '{"total":100,"used":40,"free":60}'; }
+    rc=0
+    bashio::host.disk_usage 'host.disk_usage.bad' 'INVALID_FILTER_!!!' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "host.disk_usage with the base key and a filter does not corrupt the base blob" {
+    bashio::api.supervisor() { printf '%s' '{"total":100,"used":40,"free":60}'; }
+    run bashio::host.disk_usage 'host.disk_usage' '.free'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "60" ]
+    run bashio::cache.get 'host.disk_usage'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.free')" = "60" ]
+}
+
 # ------------------------------------------------------------------------------
 # hostname getter/setter.
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
# Proposed Changes

Adds two fetchers for host endpoints not previously covered by bashio:

- `bashio::host.services` for `GET /host/services`, returning the systemd
  services available on the host (`{services: [{name, description, state}]}`).
- `bashio::host.disk_usage` for `GET /host/disks/default/usage`, returning a
  breakdown of storage usage on the system.

Both follow the standard fetcher idiom (optional cache key and jq filter,
including the guard that prevents a filtered call from overwriting the base
blob). The endpoints were verified against the Supervisor source
(`supervisor/api/host.py`).

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added host helper utilities to list available system services and to report disk usage, with optional filtering and caching support.

* **Tests**
  * Added end-to-end tests covering API interactions, filtering behavior, error propagation, and cache integrity for the new host helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->