### PR TITLE
Add lib/updates.sh covering the Supervisor update endpoints

### DIFF
--- a/lib/bashio.sh
+++ b/lib/bashio.sh
@@ -113,5 +113,7 @@ source "${__BASHIO_LIB_DIR}/supervisor.sh"
 source "${__BASHIO_LIB_DIR}/trace.sh"
 # shellcheck source=lib/try.sh
 source "${__BASHIO_LIB_DIR}/try.sh"
+# shellcheck source=lib/updates.sh
+source "${__BASHIO_LIB_DIR}/updates.sh"
 # shellcheck source=lib/var.sh
 source "${__BASHIO_LIB_DIR}/var.sh"

--- a/lib/updates.sh
+++ b/lib/updates.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# ==============================================================================
+# Home Assistant Community Apps: Bashio
+# Bashio is a bash function library for use with Home Assistant apps.
+#
+# It contains a set of commonly used operations and can be used
+# to be included in app scripts to reduce code duplication across apps.
+# ==============================================================================
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object listing the components that have an update available.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::updates() {
+    local cache_key=${1:-'updates.available'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'updates.available' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'updates.available'; then
+        info=$(bashio::cache.get 'updates.available')
+    else
+        info=$(bashio::api.supervisor GET /available_updates false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get available updates from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'updates.available' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'updates.available' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Refreshes the cache of the latest software versions from the version server.
+# ------------------------------------------------------------------------------
+function bashio::updates.refresh() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::api.supervisor POST /refresh_updates || return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Reloads the add-on stores and reads the latest version information.
+# ------------------------------------------------------------------------------
+function bashio::updates.reload() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::api.supervisor POST /reload_updates || return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}

--- a/tests/updates.bats
+++ b/tests/updates.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# ==============================================================================
+# Tests for lib/updates.sh.
+#
+# These tests stub the API boundary (`bashio::api.supervisor`) and let the real
+# `bashio::updates` fetcher, jq filtering, and caching run. The cache is pointed
+# at a per-test temporary directory so tests stay isolated.
+# ==============================================================================
+
+source "${BATS_TEST_DIRNAME}/test_helper.bash"
+
+setup() {
+    __BASHIO_CACHE_DIR="${BATS_TEST_TMPDIR}/cache"
+}
+
+UPDATES_JSON='{"available_updates":[{"update_type":"core","version_latest":"2"}]}'
+
+# ------------------------------------------------------------------------------
+# bashio::updates (fetcher)
+# ------------------------------------------------------------------------------
+
+@test "updates calls GET /available_updates" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' "${UPDATES_JSON}"
+    }
+    run bashio::updates
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /available_updates false" ]
+    [ "${output}" = "${UPDATES_JSON}" ]
+}
+
+@test "updates applies an optional jq filter" {
+    bashio::api.supervisor() { printf '%s' "${UPDATES_JSON}"; }
+    run bashio::updates 'updates.available.type' '.available_updates[0].update_type'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "core" ]
+}
+
+@test "updates returns cached data on a second call without hitting the API" {
+    local call_file="${BATS_TEST_TMPDIR}/calls"
+    printf '0' >"${call_file}"
+    bashio::api.supervisor() {
+        printf '%d' $(($(cat "${call_file}") + 1)) >"${call_file}"
+        printf '%s' "${UPDATES_JSON}"
+    }
+    bashio::updates >/dev/null
+    bashio::updates >/dev/null
+    [ "$(cat "${call_file}")" -eq 1 ]
+}
+
+@test "updates propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::updates || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "updates propagates a jq filter failure" {
+    bashio::api.supervisor() { printf '%s' "${UPDATES_JSON}"; }
+    rc=0
+    bashio::updates 'updates.available.bad' 'INVALID_FILTER_!!!' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "updates with the base key and a filter does not corrupt the base blob" {
+    bashio::api.supervisor() { printf '%s' "${UPDATES_JSON}"; }
+    run bashio::updates 'updates.available' '.available_updates[0].update_type'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "core" ]
+    run bashio::cache.get 'updates.available'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.available_updates[0].update_type')" = "core" ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::updates.refresh
+# ------------------------------------------------------------------------------
+
+@test "updates.refresh posts to the refresh endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::updates.refresh
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /refresh_updates" ]
+}
+
+@test "updates.refresh propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::updates.refresh || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "updates.refresh flushes the cache after a successful refresh" {
+    bashio::cache.set 'updates.available' 'stale'
+    bashio::api.supervisor() { return 0; }
+    run bashio::updates.refresh
+    [ "${status}" -eq 0 ]
+    run bashio::cache.exists 'updates.available'
+    [ "${status}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::updates.reload
+# ------------------------------------------------------------------------------
+
+@test "updates.reload posts to the reload endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::updates.reload
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /reload_updates" ]
+}
+
+@test "updates.reload propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::updates.reload || rc=$?
+    [ "${rc}" -ne 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

Adds a new `lib/updates.sh` module wrapping the root-level update endpoints,
which had no natural home in an existing module:

- `bashio::updates`: a fetcher for `GET /available_updates` (the components that
  have an update available), with an optional cache key and jq filter, following
  the standard fetcher idiom including the base-blob guard.
- `bashio::updates.refresh`: `POST /refresh_updates`, refreshing the cached
  latest versions from the version server.
- `bashio::updates.reload`: `POST /reload_updates`, reloading the add-on stores.

Endpoints verified against the Supervisor source (`supervisor/api/root.py`).
Full suite green (1154 tests), shellcheck and shfmt clean.

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>