### PR TITLE
Add PulseAudio control helpers to lib/audio.sh

### DIFF
--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -54,6 +54,139 @@ function bashio::audio.logs() {
 }
 
 # ------------------------------------------------------------------------------
+# Sets the volume on an audio stream.
+#
+# Arguments:
+#   $1 Stream type ('input' or 'output')
+#   $2 Stream index
+#   $3 Volume level (a number between 0 and 1, e.g. 0.5)
+#   $4 Apply to the application stream instead of the device (optional)
+# ------------------------------------------------------------------------------
+function bashio::audio.volume() {
+    local source=${1}
+    local index=${2}
+    local volume=${3}
+    local application=${4:-false}
+    local resource
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if [[ ! "${source}" =~ ^(input|output)$ ]]; then
+        bashio::log.error "Invalid stream type, expected 'input' or 'output'"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+    if [[ ! "${index}" =~ ^(0|[1-9][0-9]*)$ ]]; then
+        bashio::log.error "Invalid index, expected a non-negative integer"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+    if [[ ! "${volume}" =~ ^(0|[1-9][0-9]*)(\.[0-9]+)?$ ]]; then
+        bashio::log.error "Invalid volume, expected a non-negative number"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    resource="/audio/volume/${source}"
+    if bashio::var.true "${application}"; then
+        resource="${resource}/application"
+    fi
+
+    payload=$(bashio::var.json index "^${index}" volume "^${volume}")
+    bashio::api.supervisor POST "${resource}" "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Mutes or unmutes an audio stream.
+#
+# Arguments:
+#   $1 Stream type ('input' or 'output')
+#   $2 Stream index
+#   $3 Mute state (true to mute, false to unmute)
+#   $4 Apply to the application stream instead of the device (optional)
+# ------------------------------------------------------------------------------
+function bashio::audio.mute() {
+    local source=${1}
+    local index=${2}
+    local active=${3}
+    local application=${4:-false}
+    local resource
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if [[ ! "${source}" =~ ^(input|output)$ ]]; then
+        bashio::log.error "Invalid stream type, expected 'input' or 'output'"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+    if [[ ! "${index}" =~ ^(0|[1-9][0-9]*)$ ]]; then
+        bashio::log.error "Invalid index, expected a non-negative integer"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    if bashio::var.true "${active}"; then
+        active='^true'
+    else
+        active='^false'
+    fi
+
+    resource="/audio/mute/${source}"
+    if bashio::var.true "${application}"; then
+        resource="${resource}/application"
+    fi
+
+    payload=$(bashio::var.json index "^${index}" active "${active}")
+    bashio::api.supervisor POST "${resource}" "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Sets the default audio stream.
+#
+# Arguments:
+#   $1 Stream type ('input' or 'output')
+#   $2 Name of the stream to set as default
+# ------------------------------------------------------------------------------
+function bashio::audio.default() {
+    local source=${1}
+    local name=${2}
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if [[ ! "${source}" =~ ^(input|output)$ ]]; then
+        bashio::log.error "Invalid stream type, expected 'input' or 'output'"
+        return "${__BASHIO_EXIT_NOK}"
+    fi
+
+    payload=$(bashio::var.json name "${name}")
+    bashio::api.supervisor POST "/audio/default/${source}" "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Activates an audio profile on a card.
+#
+# Arguments:
+#   $1 Card identifier
+#   $2 Profile name to activate
+# ------------------------------------------------------------------------------
+function bashio::audio.profile() {
+    local card=${1}
+    local name=${2}
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    payload=$(bashio::var.json card "${card}" name "${name}")
+    bashio::api.supervisor POST /audio/profile "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
 # Returns a JSON object with generic version information about the audio server.
 #
 # Arguments:

--- a/lib/audio.sh
+++ b/lib/audio.sh
@@ -59,7 +59,8 @@ function bashio::audio.logs() {
 # Arguments:
 #   $1 Stream type ('input' or 'output')
 #   $2 Stream index
-#   $3 Volume level (a number between 0 and 1, e.g. 0.5)
+#   $3 Volume level (a non-negative number where 1.0 is 100%, e.g. 0.5;
+#      values above 1.0 amplify the stream)
 #   $4 Apply to the application stream instead of the device (optional)
 # ------------------------------------------------------------------------------
 function bashio::audio.volume() {

--- a/tests/audio.bats
+++ b/tests/audio.bats
@@ -93,6 +93,157 @@ setup() {
 }
 
 # ------------------------------------------------------------------------------
+# bashio::audio.volume
+# ------------------------------------------------------------------------------
+
+@test "audio.volume posts index and volume to the device stream endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.volume "output" "0" "0.5"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/volume/output {"index":0,"volume":0.5}' ]
+}
+
+@test "audio.volume targets the application stream when requested" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.volume "input" "2" "1" "true"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/volume/input/application {"index":2,"volume":1}' ]
+}
+
+@test "audio.volume rejects an invalid stream type without calling the API" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::audio.volume "speaker" "0" "0.5" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "audio.volume rejects a non-numeric index and cannot inject extra keys" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::audio.volume "output" '0,"x":1' "0.5" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "audio.volume rejects a non-numeric volume without calling the API" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::audio.volume "output" "0" "loud" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "audio.volume propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.volume "output" "0" "0.5" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.mute
+# ------------------------------------------------------------------------------
+
+@test "audio.mute posts index and active to the device stream endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.mute "output" "1" "true"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/mute/output {"index":1,"active":true}' ]
+}
+
+@test "audio.mute normalizes the active flag and cannot inject extra keys" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::audio.mute "output" "1" 'true,"x":1'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/body")" = '{"index":1,"active":false}' ]
+    run jq -e 'has("x")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
+@test "audio.mute targets the application stream when requested" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.mute "input" "0" "false" "true"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/mute/input/application {"index":0,"active":false}' ]
+}
+
+@test "audio.mute rejects an invalid stream type without calling the API" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::audio.mute "speaker" "0" "true" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "audio.mute propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.mute "output" "0" "true" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.default
+# ------------------------------------------------------------------------------
+
+@test "audio.default posts the stream name to the default endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.default "output" "alsa_output.0"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/default/output {"name":"alsa_output.0"}' ]
+}
+
+@test "audio.default escapes the name and cannot inject extra keys" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::audio.default "output" 'x","y":"z'
+    [ "${status}" -eq 0 ]
+    run jq -e 'has("y")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
+@test "audio.default rejects an invalid stream type without calling the API" {
+    bashio::api.supervisor() { echo "called" >"${BATS_TEST_TMPDIR}/call"; }
+    rc=0
+    bashio::audio.default "speaker" "x" || rc=$?
+    [ "${rc}" -ne 0 ]
+    [ ! -e "${BATS_TEST_TMPDIR}/call" ]
+}
+
+@test "audio.default propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.default "output" "x" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::audio.profile
+# ------------------------------------------------------------------------------
+
+@test "audio.profile posts the card and profile name" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::audio.profile "card0" "output:analog-stereo"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /audio/profile {"card":"card0","name":"output:analog-stereo"}' ]
+}
+
+@test "audio.profile escapes its arguments and cannot inject extra keys" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::audio.profile 'x","y":"z' "name"
+    [ "${status}" -eq 0 ]
+    run jq -e 'has("y")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
+@test "audio.profile propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::audio.profile "card0" "x" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
 # bashio::audio (info fetcher)
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
# Proposed Changes

Adds setters for the audio (PulseAudio) control endpoints that bashio did not
yet cover:

- `bashio::audio.volume` - `POST /audio/volume/<source>[/application]`
- `bashio::audio.mute` - `POST /audio/mute/<source>[/application]`
- `bashio::audio.default` - `POST /audio/default/<source>`
- `bashio::audio.profile` - `POST /audio/profile`

Input handling is careful about the trust boundary:

- the stream type is validated against `input`/`output` so it cannot inject
  extra path segments into the URL;
- the index is validated as a non-negative integer and the volume as a
  non-negative number before being sent as raw JSON;
- the mute flag is normalised to a literal `true`/`false`;
- the `name`/`card` values are escaped via `bashio::var.json`.

None of the typed values can inject extra keys into the request body (covered
by tests). Endpoints and body shapes verified against the Supervisor source
(`supervisor/api/audio.py`); `StreamType` is `input`/`output`.

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audio volume controls with stream targeting and optional application-level control
  * Added audio mute management
  * Added ability to set default audio stream
  * Added audio profile management for devices

* **Tests**
  * Added comprehensive tests for the new audio controls covering input validation, request construction, injection protection, and error handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->