### PR TITLE
Add OS swap, data disk and boot-slot helpers

### DIFF
--- a/lib/os.sh
+++ b/lib/os.sh
@@ -131,3 +131,178 @@ function bashio::os.boot() {
     bashio::log.trace "${FUNCNAME[0]}"
     bashio::os 'os.info.boot' '.boot'
 }
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with the swap settings (HassOS 15.0 or newer).
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::os.swap() {
+    local cache_key=${1:-'os.swap'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'os.swap' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'os.swap'; then
+        info=$(bashio::cache.get 'os.swap')
+    else
+        info=$(bashio::api.supervisor GET /os/config/swap false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get swap settings from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'os.swap' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'os.swap' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Sets the swap settings (HassOS 15.0 or newer).
+#
+# Arguments:
+#   $1 Options object (JSON), with swap_size and/or swappiness
+# ------------------------------------------------------------------------------
+function bashio::os.swap.options() {
+    local options=${1}
+
+    # The options object is an opaque caller-provided payload, so trace only
+    # the function name, never the payload itself.
+    bashio::log.trace "${FUNCNAME[0]}"
+
+    bashio::api.supervisor POST /os/config/swap "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with the data disk targets available for migration.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::os.datadisk.list() {
+    local cache_key=${1:-'os.datadisk.list'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'os.datadisk.list' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'os.datadisk.list'; then
+        info=$(bashio::cache.get 'os.datadisk.list')
+    else
+        info=$(bashio::api.supervisor GET /os/datadisk/list false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get data disk list from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'os.datadisk.list' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'os.datadisk.list' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Moves the data partition to another disk and reboots.
+#
+# Arguments:
+#   $1 Target device id
+# ------------------------------------------------------------------------------
+function bashio::os.datadisk.move() {
+    local device=${1}
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    payload=$(bashio::var.json device "${device}")
+    bashio::api.supervisor POST /os/datadisk/move "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Wipes the data disk and reboots into a factory-reset state.
+# ------------------------------------------------------------------------------
+function bashio::os.datadisk.wipe() {
+    bashio::log.trace "${FUNCNAME[0]}"
+    bashio::api.supervisor POST /os/datadisk/wipe || return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Changes the active boot slot and reboots into it.
+#
+# Arguments:
+#   $1 Boot slot ('A' or 'B')
+# ------------------------------------------------------------------------------
+function bashio::os.boot_slot() {
+    local slot=${1}
+    local payload
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    payload=$(bashio::var.json boot_slot "${slot}")
+    bashio::api.supervisor POST /os/boot-slot "${payload}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}

--- a/tests/os.bats
+++ b/tests/os.bats
@@ -194,3 +194,148 @@ setup() {
     run bashio::os.version
     [ "${status}" -ne 0 ]
 }
+
+# ------------------------------------------------------------------------------
+# bashio::os.swap (getter) and bashio::os.swap.options (setter)
+# ------------------------------------------------------------------------------
+
+@test "os.swap calls GET /os/config/swap" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"swap_size":"1G","swappiness":60}'
+    }
+    run bashio::os.swap
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /os/config/swap false" ]
+    [ "${output}" = '{"swap_size":"1G","swappiness":60}' ]
+}
+
+@test "os.swap applies an optional jq filter" {
+    bashio::api.supervisor() { printf '%s' '{"swap_size":"1G","swappiness":60}'; }
+    run bashio::os.swap 'os.swap.swappiness' '.swappiness'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "60" ]
+}
+
+@test "os.swap propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.swap || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "os.swap with the base key and a filter does not corrupt the base blob" {
+    bashio::api.supervisor() { printf '%s' '{"swap_size":"1G","swappiness":60}'; }
+    run bashio::os.swap 'os.swap' '.swappiness'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "60" ]
+    run bashio::cache.get 'os.swap'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.swap_size')" = "1G" ]
+}
+
+@test "os.swap.options posts the given JSON to the swap endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.swap.options '{"swappiness":80}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /os/config/swap {"swappiness":80}' ]
+}
+
+@test "os.swap.options propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.swap.options '{"swappiness":80}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "os.swap.options does not log the options payload" {
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { return 0; }
+    bashio::os.swap.options '{"swap_size":"SENTINEL_VALUE"}'
+    [[ "${logged}" != *"SENTINEL_VALUE"* ]]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::os.datadisk.list / move / wipe
+# ------------------------------------------------------------------------------
+
+@test "os.datadisk.list calls GET /os/datadisk/list" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"devices":["sda"],"disks":[{"id":"sda"}]}'
+    }
+    run bashio::os.datadisk.list
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /os/datadisk/list false" ]
+    [ "${output}" = '{"devices":["sda"],"disks":[{"id":"sda"}]}' ]
+}
+
+@test "os.datadisk.list propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.datadisk.list || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "os.datadisk.move posts the target device" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.datadisk.move "sda"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /os/datadisk/move {"device":"sda"}' ]
+}
+
+@test "os.datadisk.move escapes the device and cannot inject extra keys" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::os.datadisk.move 'x","y":"z'
+    [ "${status}" -eq 0 ]
+    run jq -e 'has("y")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
+@test "os.datadisk.move propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.datadisk.move "sda" || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "os.datadisk.wipe posts to the wipe endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.datadisk.wipe
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "POST /os/datadisk/wipe" ]
+}
+
+@test "os.datadisk.wipe propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.datadisk.wipe || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::os.boot_slot
+# ------------------------------------------------------------------------------
+
+@test "os.boot_slot posts the requested slot" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.boot_slot "B"
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /os/boot-slot {"boot_slot":"B"}' ]
+}
+
+@test "os.boot_slot escapes the slot and cannot inject extra keys" {
+    bashio::api.supervisor() { printf '%s' "$3" >"${BATS_TEST_TMPDIR}/body"; }
+    run bashio::os.boot_slot 'A","y":"z'
+    [ "${status}" -eq 0 ]
+    run jq -e 'has("y")' <"${BATS_TEST_TMPDIR}/body"
+    [ "${status}" -ne 0 ]
+}
+
+@test "os.boot_slot propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.boot_slot "B" || rc=$?
+    [ "${rc}" -ne 0 ]
+}


### PR DESCRIPTION
# Proposed Changes

Adds wrappers for several HassOS management endpoints that bashio did not yet
cover (the first of two OS PRs; board-specific endpoints follow separately):

- `bashio::os.swap` / `bashio::os.swap.options` - `GET`/`POST /os/config/swap`
  (swap size and swappiness; HassOS 15.0 or newer).
- `bashio::os.datadisk.list` - `GET /os/datadisk/list`, plus
  `bashio::os.datadisk.move` and `bashio::os.datadisk.wipe` for the data disk
  migrate and wipe actions.
- `bashio::os.boot_slot` - `POST /os/boot-slot` (`A` or `B`).

The fetchers follow the standard cache/filter idiom with the base-blob guard.
The swap options setter treats its payload as opaque (not logged); the device
and boot-slot values are escaped via `bashio::var.json` so they cannot inject
extra keys (covered by tests). Endpoints and body shapes verified against the
Supervisor source (`supervisor/api/os.py`).

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for swap memory management operations.
  * Added support for data disk operations including listing targets, moving partitions, and wiping disks.
  * Added support for boot slot switching.

* **Tests**
  * Added comprehensive test coverage for all new system operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->