### PR TITLE
Add Home Assistant Green/Yellow board LED helpers

### DIFF
--- a/lib/os.sh
+++ b/lib/os.sh
@@ -306,3 +306,152 @@ function bashio::os.boot_slot() {
         return "${__BASHIO_EXIT_NOK}"
     bashio::cache.flush_all
 }
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with the LED settings of a Home Assistant Green board.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::os.boards.green() {
+    local cache_key=${1:-'os.boards.green'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'os.boards.green' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'os.boards.green'; then
+        info=$(bashio::cache.get 'os.boards.green')
+    else
+        info=$(bashio::api.supervisor GET /os/boards/green false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get green board info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'os.boards.green' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'os.boards.green' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Sets the LED settings of a Home Assistant Green board.
+#
+# Arguments:
+#   $1 Options object (JSON), with activity_led, power_led and/or
+#      system_health_led
+# ------------------------------------------------------------------------------
+function bashio::os.boards.green.options() {
+    local options=${1}
+
+    # The options object is an opaque caller-provided payload, so trace only
+    # the function name, never the payload itself.
+    bashio::log.trace "${FUNCNAME[0]}"
+
+    bashio::api.supervisor POST /os/boards/green "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}
+
+# ------------------------------------------------------------------------------
+# Returns a JSON object with the LED settings of a Home Assistant Yellow board.
+#
+# Arguments:
+#   $1 Cache key to store results in (optional)
+#   $2 jq Filter to apply on the result (optional)
+# ------------------------------------------------------------------------------
+function bashio::os.boards.yellow() {
+    local cache_key=${1:-'os.boards.yellow'}
+    local filter=${2:-}
+    local info
+    local response
+
+    bashio::log.trace "${FUNCNAME[0]}" "$@"
+
+    if bashio::cache.exists "${cache_key}"; then
+        # The base key holds the unfiltered blob, so only serve it from the
+        # cache when no filter is requested; a filtered call must recompute.
+        if [[ "${cache_key}" != 'os.boards.yellow' ]] ||
+            ! bashio::var.has_value "${filter}"; then
+            bashio::cache.get "${cache_key}"
+            return "${__BASHIO_EXIT_OK}"
+        fi
+    fi
+
+    if bashio::cache.exists 'os.boards.yellow'; then
+        info=$(bashio::cache.get 'os.boards.yellow')
+    else
+        info=$(bashio::api.supervisor GET /os/boards/yellow false)
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to get yellow board info from Supervisor API"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+        bashio::cache.set 'os.boards.yellow' "${info}"
+    fi
+
+    response="${info}"
+    if bashio::var.has_value "${filter}"; then
+        response=$(bashio::jq "${info}" "${filter}")
+        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+            bashio::log.error "Failed to execute the jq filter"
+            return "${__BASHIO_EXIT_NOK}"
+        fi
+    fi
+
+    # Never overwrite the base blob with a filtered result: the
+    # base blob is already cached above, so only cache under a distinct
+    # caller-provided key.
+    if [[ "${cache_key}" != 'os.boards.yellow' ]]; then
+        bashio::cache.set "${cache_key}" "${response}"
+    fi
+    printf "%s" "${response}"
+
+    return "${__BASHIO_EXIT_OK}"
+}
+
+# ------------------------------------------------------------------------------
+# Sets the LED settings of a Home Assistant Yellow board.
+#
+# Arguments:
+#   $1 Options object (JSON), with disk_led, heartbeat_led and/or power_led
+# ------------------------------------------------------------------------------
+function bashio::os.boards.yellow.options() {
+    local options=${1}
+
+    # The options object is an opaque caller-provided payload, so trace only
+    # the function name, never the payload itself.
+    bashio::log.trace "${FUNCNAME[0]}"
+
+    bashio::api.supervisor POST /os/boards/yellow "${options}" ||
+        return "${__BASHIO_EXIT_NOK}"
+    bashio::cache.flush_all
+}

--- a/tests/os.bats
+++ b/tests/os.bats
@@ -339,3 +339,107 @@ setup() {
     bashio::os.boot_slot "B" || rc=$?
     [ "${rc}" -ne 0 ]
 }
+
+# ------------------------------------------------------------------------------
+# bashio::os.boards.green (getter + options setter)
+# ------------------------------------------------------------------------------
+
+@test "os.boards.green calls GET /os/boards/green" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"activity_led":true,"power_led":true,"system_health_led":false}'
+    }
+    run bashio::os.boards.green
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /os/boards/green false" ]
+    [ "${output}" = '{"activity_led":true,"power_led":true,"system_health_led":false}' ]
+}
+
+@test "os.boards.green applies an optional jq filter" {
+    bashio::api.supervisor() { printf '%s' '{"activity_led":true,"power_led":false}'; }
+    run bashio::os.boards.green 'os.boards.green.power' '.power_led'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+}
+
+@test "os.boards.green propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.boards.green || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "os.boards.green with the base key and a filter does not corrupt the base blob" {
+    bashio::api.supervisor() { printf '%s' '{"activity_led":true,"power_led":false}'; }
+    run bashio::os.boards.green 'os.boards.green' '.power_led'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+    run bashio::cache.get 'os.boards.green'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.activity_led')" = "true" ]
+}
+
+@test "os.boards.green.options posts the given JSON to the green endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.boards.green.options '{"power_led":false}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /os/boards/green {"power_led":false}' ]
+}
+
+@test "os.boards.green.options propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.boards.green.options '{"power_led":false}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "os.boards.green.options does not log the options payload" {
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { return 0; }
+    bashio::os.boards.green.options '{"power_led":"SENTINEL_VALUE"}'
+    [[ "${logged}" != *"SENTINEL_VALUE"* ]]
+}
+
+# ------------------------------------------------------------------------------
+# bashio::os.boards.yellow (getter + options setter)
+# ------------------------------------------------------------------------------
+
+@test "os.boards.yellow calls GET /os/boards/yellow" {
+    bashio::api.supervisor() {
+        echo "$*" >"${BATS_TEST_TMPDIR}/call"
+        printf '%s' '{"disk_led":true,"heartbeat_led":true,"power_led":true}'
+    }
+    run bashio::os.boards.yellow
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = "GET /os/boards/yellow false" ]
+    [ "${output}" = '{"disk_led":true,"heartbeat_led":true,"power_led":true}' ]
+}
+
+@test "os.boards.yellow applies an optional jq filter" {
+    bashio::api.supervisor() { printf '%s' '{"disk_led":true,"power_led":false}'; }
+    run bashio::os.boards.yellow 'os.boards.yellow.disk' '.disk_led'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "true" ]
+}
+
+@test "os.boards.yellow propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.boards.yellow || rc=$?
+    [ "${rc}" -ne 0 ]
+}
+
+@test "os.boards.yellow.options posts the given JSON to the yellow endpoint" {
+    bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
+    run bashio::os.boards.yellow.options '{"disk_led":false}'
+    [ "${status}" -eq 0 ]
+    [ "$(cat "${BATS_TEST_TMPDIR}/call")" = 'POST /os/boards/yellow {"disk_led":false}' ]
+}
+
+@test "os.boards.yellow.options propagates an API failure" {
+    bashio::api.supervisor() { return 1; }
+    rc=0
+    bashio::os.boards.yellow.options '{"disk_led":false}' || rc=$?
+    [ "${rc}" -ne 0 ]
+}

--- a/tests/os.bats
+++ b/tests/os.bats
@@ -430,6 +430,16 @@ setup() {
     [ "${rc}" -ne 0 ]
 }
 
+@test "os.boards.yellow with the base key and a filter does not corrupt the base blob" {
+    bashio::api.supervisor() { printf '%s' '{"disk_led":true,"power_led":false}'; }
+    run bashio::os.boards.yellow 'os.boards.yellow' '.power_led'
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "false" ]
+    run bashio::cache.get 'os.boards.yellow'
+    [ "${status}" -eq 0 ]
+    [ "$(printf '%s' "${output}" | jq -r '.disk_led')" = "true" ]
+}
+
 @test "os.boards.yellow.options posts the given JSON to the yellow endpoint" {
     bashio::api.supervisor() { echo "$*" >"${BATS_TEST_TMPDIR}/call"; }
     run bashio::os.boards.yellow.options '{"disk_led":false}'
@@ -442,4 +452,12 @@ setup() {
     rc=0
     bashio::os.boards.yellow.options '{"disk_led":false}' || rc=$?
     [ "${rc}" -ne 0 ]
+}
+
+@test "os.boards.yellow.options does not log the options payload" {
+    logged=""
+    bashio::log.trace() { logged+=" $*"; }
+    bashio::api.supervisor() { return 0; }
+    bashio::os.boards.yellow.options '{"disk_led":"SENTINEL_VALUE"}'
+    [[ "${logged}" != *"SENTINEL_VALUE"* ]]
 }


### PR DESCRIPTION
# Proposed Changes

Second of the OS PRs: adds getters and option setters for the board-specific
LED endpoints.

- `bashio::os.boards.green` / `bashio::os.boards.green.options` -
  `GET`/`POST /os/boards/green` (`activity_led`, `power_led`,
  `system_health_led`).
- `bashio::os.boards.yellow` / `bashio::os.boards.yellow.options` -
  `GET`/`POST /os/boards/yellow` (`disk_led`, `heartbeat_led`, `power_led`).

The getters follow the standard cache/filter idiom with the base-blob guard;
the option setters treat their payload as opaque (not logged). The generic
`/os/boards/{board}` endpoint is intentionally not wrapped: it returns an empty
object (a board-in-use check) with no useful data. Endpoints and body shapes
verified against the Supervisor source (`supervisor/api/os.py`).

Part of closing the remaining gap between bashio and the Supervisor API.

## Related Issues

>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LED configuration management for Home Assistant boards, enabling retrieval and updates of LED settings with optional filtering and caching, plus graceful handling of API or processing errors.

* **Tests**
  * Added comprehensive tests covering retrieval, update, filtering, caching behavior, error propagation, and ensuring sensitive payloads are not logged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->