### PR TITLE
Fix "Unable to access the API, forbidden" errors on bashio::app functions

### DIFF
--- a/lib/apps.sh
+++ b/lib/apps.sh
@@ -192,8 +192,7 @@ function bashio::apps() {
 
     if bashio::var.false "${slug}" || \
         ( ! bashio::var.equals "${slug}" "self" && \
-        bashio::cache.exists "addons.${slug}.info" )
-    then
+            ! bashio::cache.exists "addons.${slug}.info" ); then
         if bashio::cache.exists "store.addons.info"; then
             info=$(bashio::cache.get "store.addons.info")
         else

--- a/lib/apps.sh
+++ b/lib/apps.sh
@@ -190,15 +190,19 @@ function bashio::apps() {
         return "${__BASHIO_EXIT_OK}"
     fi
 
-    if bashio::cache.exists "store.addons.info"; then
-        info=$(bashio::cache.get "store.addons.info")
-    else
-        info=$(bashio::api.supervisor GET "/store/addons" false)
-        if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
-            bashio::log.error "Failed to get addons info from Supervisor API"
-            return "${__BASHIO_EXIT_NOK}"
+    if bashio::var.false "${slug}" || \
+      ! bashio::var.equals "${slug}" "self"
+    then
+        if bashio::cache.exists "store.addons.info"; then
+            info=$(bashio::cache.get "store.addons.info")
+        else
+            info=$(bashio::api.supervisor GET "/store/addons" false)
+            if [ "$?" -ne "${__BASHIO_EXIT_OK}" ]; then
+                bashio::log.error "Failed to get addons info from Supervisor API"
+                return "${__BASHIO_EXIT_NOK}"
+            fi
+            bashio::cache.set "store.addons.info" "${info}"
         fi
-        bashio::cache.set "store.addons.info" "${info}"
     fi
 
     if ! bashio::var.false "${slug}"; then

--- a/lib/apps.sh
+++ b/lib/apps.sh
@@ -190,9 +190,9 @@ function bashio::apps() {
         return "${__BASHIO_EXIT_OK}"
     fi
 
-    if bashio::var.false "${slug}" || \
-        ( ! bashio::var.equals "${slug}" "self" && \
-            ! bashio::cache.exists "addons.${slug}.info" ); then
+    if bashio::var.false "${slug}" ||
+        (! bashio::var.equals "${slug}" "self" &&
+            ! bashio::cache.exists "addons.${slug}.info"); then
         if bashio::cache.exists "store.addons.info"; then
             info=$(bashio::cache.get "store.addons.info")
         else

--- a/lib/apps.sh
+++ b/lib/apps.sh
@@ -191,7 +191,8 @@ function bashio::apps() {
     fi
 
     if bashio::var.false "${slug}" || \
-      ! bashio::var.equals "${slug}" "self"
+        ( ! bashio::var.equals "${slug}" "self" && \
+            bashio::cache.exists "addons.${slug}.info" )
     then
         if bashio::cache.exists "store.addons.info"; then
             info=$(bashio::cache.get "store.addons.info")

--- a/lib/apps.sh
+++ b/lib/apps.sh
@@ -192,7 +192,7 @@ function bashio::apps() {
 
     if bashio::var.false "${slug}" || \
         ( ! bashio::var.equals "${slug}" "self" && \
-            bashio::cache.exists "addons.${slug}.info" )
+        bashio::cache.exists "addons.${slug}.info" )
     then
         if bashio::cache.exists "store.addons.info"; then
             info=$(bashio::cache.get "store.addons.info")

--- a/tests/apps.bats
+++ b/tests/apps.bats
@@ -267,8 +267,9 @@ store_listing() {
     [ "${lines[1]}" = "GET /store/addons/beta false" ]
 }
 
-@test "addons for the self slug uses the installed info endpoint" {
-    # self is treated as installed without consulting the listing for state.
+@test "addons for the self slug uses the installed info endpoint without consulting the store listing" {
+    # self is known to be installed, so the restricted /store/addons listing
+    # must not be consulted at all; the only call is the installed-info endpoint.
     bashio::api.supervisor() {
         echo "$*" >>"${BATS_TEST_TMPDIR}/calls"
         if [[ "$2" == "/store/addons" ]]; then
@@ -281,7 +282,20 @@ store_listing() {
     [ "${status}" -eq 0 ]
     [ "${output}" = "selfslug" ]
     run cat "${BATS_TEST_TMPDIR}/calls"
-    [ "${lines[1]}" = "GET /addons/self/info false" ]
+    [ "${#lines[@]}" -eq 1 ]
+    [ "${lines[0]}" = "GET /addons/self/info false" ]
+}
+
+@test "addons for a cached slug does not consult the store listing" {
+    # When the per-addon info is already cached, the install state is known, so
+    # the restricted /store/addons listing must not be consulted.
+    bashio::cache.set "addons.alpha.info" '{"slug":"alpha"}'
+    bashio::api.supervisor() { echo "$*" >>"${BATS_TEST_TMPDIR}/calls"; }
+    run bashio::apps "alpha"
+    [ "${status}" -eq 0 ]
+    [ "${output}" = "alpha" ]
+    # No API call is made at all (neither the store listing nor the info endpoint).
+    [ ! -f "${BATS_TEST_TMPDIR}/calls" ]
 }
 
 @test "addons applies a custom jq filter and caches under a custom key" {


### PR DESCRIPTION
# Proposed Changes

Accessing `/store/addons` is restricted, but it is used for determining whether an app is installed or not if a slug is used.

But it was accessed even when a `self` slug was used and we know that the app is installed.

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Reduced unnecessary external addon lookups when viewing the local addon or when per-addon info is cached, improving responsiveness and lowering latency.
* **Tests**
  * Tightened test coverage to ensure no extra external calls occur for the local addon and when per-addon cache exists, preventing regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->