### PR TITLE
Fix closed LOG_FD 10 detection

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -8,7 +8,15 @@
 # ==============================================================================
 
 # Unless $LOG_FD is already set to a valid fd.
-if ! [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]] || ! { : >&"${LOG_FD:-}"; } 2>/dev/null; then
+#
+# The probe silences stderr with `exec` in a subshell: a `2>/dev/null` on the
+# probe itself would make bash park the saved stderr on the lowest free
+# fd >= 10 for the duration of the redirection, which can be $LOG_FD itself,
+# making a closed fd appear valid.
+if ! [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]] || ! (
+    exec 2>/dev/null
+    : >&"${LOG_FD:-}"
+); then
     # Preserve the original STDOUT on a free fd (stored in $LOG_FD) so that we can
     # log to it without interfering with the STDOUT of subshells or child processes
     # whose output we want to capture for other purposes.
@@ -29,7 +37,10 @@ export LOG_FD
 # want the log functions to log to the new STDOUT.
 # ------------------------------------------------------------------------------
 function bashio::log.reinitialize_output() {
-    if [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]] && { : >&"${LOG_FD}"; } 2>/dev/null; then
+    if [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]] && (
+        exec 2>/dev/null
+        : >&"${LOG_FD}"
+    ); then
         eval "exec ${LOG_FD}>&1"
     fi
 }

--- a/lib/log.sh
+++ b/lib/log.sh
@@ -8,11 +8,7 @@
 # ==============================================================================
 
 # Unless $LOG_FD is already set to a valid fd.
-#
-# The probe silences stderr with `exec` in a subshell: a `2>/dev/null` on the
-# probe itself would make bash park the saved stderr on the lowest free
-# fd >= 10 for the duration of the redirection, which can be $LOG_FD itself,
-# making a closed fd appear valid.
+# Use a subshell so suppressing errors cannot temporarily occupy $LOG_FD.
 if ! [[ "${LOG_FD:-}" =~ ^[0-9]+$ ]] || ! (
     exec 2>/dev/null
     : >&"${LOG_FD:-}"

--- a/tests/log.bats
+++ b/tests/log.bats
@@ -143,13 +143,6 @@ setup() {
 }
 
 @test "library init reopens an inherited LOG_FD whose fd is closed" {
-    # An exported LOG_FD can reach environments that inherit the variable but
-    # not the descriptor (e.g. a shell spawned through ttyd/tmux), so it names
-    # a closed fd. The init probe must not apply `2>/dev/null` to the probe
-    # command itself: setting that up parks bash's saved stderr on the lowest
-    # free fd >= 10 — the very fd `exec {LOG_FD}>&1` hands out — so a closed
-    # fd 10 appeared valid and the first log write died with
-    # "Bad file descriptor".
     run env LOG_FD=10 bash -c '
         exec 10>&-
         source "$1/lib/bashio.sh"
@@ -160,8 +153,6 @@ setup() {
 }
 
 @test "library init keeps an inherited LOG_FD whose fd is open" {
-    # A parent that hands down a live LOG_FD expects the child's logging to
-    # land on that fd, not on a fresh dup of the child's stdout.
     run env LOG_FD=10 bash -c '
         exec 10>"$2"
         source "$1/lib/bashio.sh"

--- a/tests/log.bats
+++ b/tests/log.bats
@@ -141,3 +141,34 @@ setup() {
     run bashio::log "still logging"
     [ "${output}" = "still logging" ]
 }
+
+@test "library init reopens an inherited LOG_FD whose fd is closed" {
+    # An exported LOG_FD can reach environments that inherit the variable but
+    # not the descriptor (e.g. a shell spawned through ttyd/tmux), so it names
+    # a closed fd. The init probe must not apply `2>/dev/null` to the probe
+    # command itself: setting that up parks bash's saved stderr on the lowest
+    # free fd >= 10 — the very fd `exec {LOG_FD}>&1` hands out — so a closed
+    # fd 10 appeared valid and the first log write died with
+    # "Bad file descriptor".
+    run env LOG_FD=10 bash -c '
+        exec 10>&-
+        source "$1/lib/bashio.sh"
+        bashio::log.info "recovered"
+    ' bash "${BASHIO_TEST_ROOT}"
+    [ "${status}" -eq 0 ]
+    [[ "${output}" == *"recovered"* ]]
+}
+
+@test "library init keeps an inherited LOG_FD whose fd is open" {
+    # A parent that hands down a live LOG_FD expects the child's logging to
+    # land on that fd, not on a fresh dup of the child's stdout.
+    run env LOG_FD=9 bash -c '
+        exec 9>"$2"
+        source "$1/lib/bashio.sh"
+        bashio::log.info "inherited"
+    ' bash "${BASHIO_TEST_ROOT}" "${BATS_TEST_TMPDIR}/inherited.log"
+    [ "${status}" -eq 0 ]
+    [ -z "${output}" ]
+    run cat "${BATS_TEST_TMPDIR}/inherited.log"
+    [[ "${output}" == *"inherited"* ]]
+}

--- a/tests/log.bats
+++ b/tests/log.bats
@@ -162,8 +162,8 @@ setup() {
 @test "library init keeps an inherited LOG_FD whose fd is open" {
     # A parent that hands down a live LOG_FD expects the child's logging to
     # land on that fd, not on a fresh dup of the child's stdout.
-    run env LOG_FD=9 bash -c '
-        exec 9>"$2"
+    run env LOG_FD=10 bash -c '
+        exec 10>"$2"
         source "$1/lib/bashio.sh"
         bashio::log.info "inherited"
     ' bash "${BASHIO_TEST_ROOT}" "${BATS_TEST_TMPDIR}/inherited.log"


### PR DESCRIPTION
# Proposed Changes

- In the [`lib/log.sh` init check](https://github.com/hassio-addons/bashio/blob/main/lib/log.sh#L10-L20), silence the `LOG_FD` probe's stderr with `exec` in a subshell instead of a redirection on the probe itself. Setting up that redirection parked bash's saved stderr on the lowest free fd >= 10—fd 10 itself when it is closed—so a dead `LOG_FD=10` passed validation and every later log write failed (full analysis in #288)

  -  In practice this broke any Bashio script launched from the web terminal of Advanced SSH & Web Terminal, whose sessions inherit `LOG_FD=10` through ttyd/tmux without the descriptor.

- Apply the same change to the identical gate in `bashio::log.reinitialize_output`.

- Add regression tests confirming that a closed inherited fd 10 is reopened while an open one is preserved.

## Related Issues

Fixes #288

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging reliability when inherited output descriptors are closed or already open.
  * Prevented temporary error-suppression behavior from affecting surrounding shell operations.

* **Tests**
  * Added coverage for reopening closed logging descriptors.
  * Verified that existing open logging descriptors continue receiving log output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->