### PR TITLE
Make exit functions accept multiple message arguments, like log functions

### DIFF
--- a/lib/exit.sh
+++ b/lib/exit.sh
@@ -11,10 +11,10 @@
 # Exit the script as failed with an optional error message.
 #
 # Arguments:
-#   $1 Error message (optional)
+#   $* Error message (optional)
 # ------------------------------------------------------------------------------
 function bashio::exit.nok() {
-    local message=${1:-}
+    local message=$*
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
@@ -30,11 +30,11 @@ function bashio::exit.nok() {
 #
 # Arguments:
 #   $1 Value to check if false
-#   $2 Error message (optional)
+#   $* Error message (optional)
 # ------------------------------------------------------------------------------
 function bashio::exit.die_if_false() {
     local value=${1:-}
-    local message=${2:-}
+    local message=${*:2}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
@@ -48,11 +48,11 @@ function bashio::exit.die_if_false() {
 #
 # Arguments:
 #   $1 Value to check if true
-#   $2 Error message (optional)
+#   $* Error message (optional)
 # ------------------------------------------------------------------------------
 function bashio::exit.die_if_true() {
     local value=${1:-}
-    local message=${2:-}
+    local message=${*:2}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 
@@ -75,11 +75,11 @@ function hass.die_if_true() { # codespell:ignore
 #
 # Arguments:
 #   $1 Value to check if empty
-#   $2 Error message (optional)
+#   $* Error message (optional)
 # ------------------------------------------------------------------------------
 function bashio::exit.die_if_empty() {
     local value=${1:-}
-    local message=${2:-}
+    local message=${*:2}
 
     bashio::log.trace "${FUNCNAME[0]}" "$@"
 

--- a/tests/exit.bats
+++ b/tests/exit.bats
@@ -39,7 +39,7 @@ setup() {
 @test "exit.nok logs multiple messages at fatal level before exiting" {
     run bashio::exit.nok "something" "broke"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: ?????something broke????"* ]]
+    [[ "${output}" == *"$(printf '%b' "FATAL: ${__BASHIO_COLORS_RED}something broke${__BASHIO_COLORS_RESET}")"* ]]
 }
 
 @test "die_if_false exits when the value is false" {
@@ -89,15 +89,15 @@ setup() {
 @test "the die_if_* helpers forward their multiple messages to the fatal log" {
     run bashio::exit.die_if_false "false" "boom from" "die_if_false"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: ?????boom from die_if_false????"* ]]
+    [[ "${output}" == *"$(printf '%b' "FATAL: ${__BASHIO_COLORS_RED}boom from die_if_false${__BASHIO_COLORS_RESET}")"* ]]
 
     run bashio::exit.die_if_true "true" "boom from" "die_if_true"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: ?????boom from die_if_true????"* ]]
+    [[ "${output}" == *"$(printf '%b' "FATAL: ${__BASHIO_COLORS_RED}boom from die_if_true${__BASHIO_COLORS_RESET}")"* ]]
 
     run bashio::exit.die_if_empty "" "boom from" "die_if_empty"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: ?????boom from die_if_empty????"* ]]
+    [[ "${output}" == *"$(printf '%b' "FATAL: ${__BASHIO_COLORS_RED}boom from die_if_empty${__BASHIO_COLORS_RESET}")"* ]]
 }
 
 @test "the deprecated die_if_true alias warns and still delegates" {

--- a/tests/exit.bats
+++ b/tests/exit.bats
@@ -36,6 +36,13 @@ setup() {
     [[ "${output}" == *"something broke"* ]]
 }
 
+@test "exit.nok logs multiple messages at fatal level before exiting" {
+    run bashio::exit.nok "something" "broke"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"FATAL"* ]]
+    [[ "${output}" == *"something broke"* ]]
+}
+
 @test "die_if_false exits when the value is false" {
     run bashio::exit.die_if_false "false"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
@@ -76,6 +83,20 @@ setup() {
     [[ "${output}" == *"boom from die_if_true"* ]]
 
     run bashio::exit.die_if_empty "" "boom from die_if_empty"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"boom from die_if_empty"* ]]
+}
+
+@test "the die_if_* helpers forward their multiple messages to the fatal log" {
+    run bashio::exit.die_if_false "false" "boom from" "die_if_false"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"boom from die_if_false"* ]]
+
+    run bashio::exit.die_if_true "true" "boom from" "die_if_true"
+    [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
+    [[ "${output}" == *"boom from die_if_true"* ]]
+
+    run bashio::exit.die_if_empty "" "boom from" "die_if_empty"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
     [[ "${output}" == *"boom from die_if_empty"* ]]
 }

--- a/tests/exit.bats
+++ b/tests/exit.bats
@@ -39,7 +39,7 @@ setup() {
 @test "exit.nok logs multiple messages at fatal level before exiting" {
     run bashio::exit.nok "something" "broke"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: something broke"* ]]
+    [[ "${output}" == *"FATAL: ?????something broke????"* ]]
 }
 
 @test "die_if_false exits when the value is false" {
@@ -89,15 +89,15 @@ setup() {
 @test "the die_if_* helpers forward their multiple messages to the fatal log" {
     run bashio::exit.die_if_false "false" "boom from" "die_if_false"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: boom from die_if_false"* ]]
+    [[ "${output}" == *"FATAL: ?????boom from die_if_false????"* ]]
 
     run bashio::exit.die_if_true "true" "boom from" "die_if_true"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: boom from die_if_true"* ]]
+    [[ "${output}" == *"FATAL: ?????boom from die_if_true????"* ]]
 
     run bashio::exit.die_if_empty "" "boom from" "die_if_empty"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL: boom from die_if_empty"* ]]
+    [[ "${output}" == *"FATAL: ?????boom from die_if_empty????"* ]]
 }
 
 @test "the deprecated die_if_true alias warns and still delegates" {

--- a/tests/exit.bats
+++ b/tests/exit.bats
@@ -39,8 +39,7 @@ setup() {
 @test "exit.nok logs multiple messages at fatal level before exiting" {
     run bashio::exit.nok "something" "broke"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"FATAL"* ]]
-    [[ "${output}" == *"something broke"* ]]
+    [[ "${output}" == *"FATAL: something broke"* ]]
 }
 
 @test "die_if_false exits when the value is false" {
@@ -90,15 +89,15 @@ setup() {
 @test "the die_if_* helpers forward their multiple messages to the fatal log" {
     run bashio::exit.die_if_false "false" "boom from" "die_if_false"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"boom from die_if_false"* ]]
+    [[ "${output}" == *"FATAL: boom from die_if_false"* ]]
 
     run bashio::exit.die_if_true "true" "boom from" "die_if_true"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"boom from die_if_true"* ]]
+    [[ "${output}" == *"FATAL: boom from die_if_true"* ]]
 
     run bashio::exit.die_if_empty "" "boom from" "die_if_empty"
     [ "${status}" -eq "${__BASHIO_EXIT_NOK}" ]
-    [[ "${output}" == *"boom from die_if_empty"* ]]
+    [[ "${output}" == *"FATAL: boom from die_if_empty"* ]]
 }
 
 @test "the deprecated die_if_true alias warns and still delegates" {


### PR DESCRIPTION
# Proposed Changes

This is backward compatible, non-breaking.

Makes the below lines working like bashio::log.fatal() works:

```
bashio::exit.nok \
  "This is a" \
  "very long message"
```

## Related Issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Exit helper messages now include all provided arguments, ensuring complete error details are displayed.
  * Fatal exit messages now preserve the correct failure status while showing the full message.
* **Documentation**
  * Updated exit helper documentation to reflect support for multi-argument messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->