### PR TITLE
Pin CI tooling with lockfiles instead of ad-hoc installs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -64,7 +64,14 @@ loads the library so its functions are available to the tests. When you fix a
 bug or add a function, please add a test that covers it.
 
 In CI the suite runs under [bashcov][bashcov] and coverage is uploaded to both
-[Codecov][codecov] and GitHub's native code coverage.
+[Codecov][codecov] and GitHub's native code coverage. The coverage tooling is
+pinned in the [`Gemfile`](../Gemfile) and [`Gemfile.lock`](../Gemfile.lock), so
+with Ruby available you can reproduce the CI run locally:
+
+```bash
+bundle install
+bundle exec bashcov -- bats tests/
+```
 
 ## Pull request process
 

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,6 +19,12 @@
       "matchManagers": ["pre-commit"],
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
+    },
+    {
+      "matchManagers": ["bundler", "pip_requirements"],
+      "rangeStrategy": "bump",
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true
     }
   ]
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         with:
           python-version: ${{ env.DEFAULT_PYTHON }}
       - name: 🏗 Install zizmor
-        run: pip install zizmor
+        run: pip install -r requirements.txt
       - name: 🚀 Run zizmor
         run: zizmor .github/workflows/
         env:
@@ -127,10 +127,9 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           ruby-version: "3.4"
-      - name: 🏗 Install coverage tooling
-        run: gem install --no-document bashcov simplecov-cobertura
+          bundler-cache: true
       - name: 🚀 Run tests with coverage
-        run: bashcov -- bats tests/
+        run: bundle exec bashcov -- bats tests/
       - name: 📤 Upload coverage to Codecov
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ coverage/
 *.cov
 cov.xml
 
+# Ruby / Bundler
+.bundle/
+vendor/bundle/
+
 # Editor & OS cruft
 .DS_Store
 Thumbs.db

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Ruby tooling used to measure test coverage of the Bats test suite.
+# The resolved versions are pinned in Gemfile.lock, install them with:
+#
+#   bundle install
+#
+source "https://rubygems.org"
+
+gem "bashcov", "~> 3.3"
+gem "simplecov-cobertura", "~> 3.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,28 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    bashcov (3.3.0)
+      simplecov (~> 0.21)
+    docile (1.4.1)
+    rexml (3.4.4)
+    simplecov (0.22.0)
+      docile (~> 1.1)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (3.2.0)
+      rexml
+      simplecov (~> 0.19)
+    simplecov-html (0.13.2)
+    simplecov_json_formatter (0.1.4)
+
+PLATFORMS
+  aarch64-linux
+  ruby
+  x86_64-linux
+
+DEPENDENCIES
+  bashcov (~> 3.3)
+  simplecov-cobertura (~> 3.2)
+
+BUNDLED WITH
+   2.6.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+# Python tooling used by the CI workflows, pinned so a new release cannot
+# break the pipeline unannounced. Renovate keeps these up to date.
+zizmor==1.29.0


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The zizmor `adhoc-packages` audit (added in a recent zizmor release) flags installing packages outside of a lockfile. That made the zizmor job fail on the ad-hoc `gem install` of the coverage tooling, breaking CI on every open pull request.

Rather than suppressing the finding, this addresses it properly:

- The Ruby coverage tooling moves into a `Gemfile` / `Gemfile.lock`, installed and cached by `ruby/setup-ruby` (`bundler-cache: true`), with the suite running through `bundle exec bashcov -- bats tests/`.
- zizmor itself is pinned in a new `requirements.txt`, so a new release introducing new audits can no longer break CI unannounced.
- Renovate is configured to keep both the bundler and pip requirements up to date, automerging minor/patch just like the pre-commit hooks.
- `CONTRIBUTING.md` documents the local `bundle install` / `bundle exec bashcov` flow, and `.bundle/` plus `vendor/bundle/` are gitignored.

As a side effect this fixes an actual latent conflict. `simplecov-cobertura` 4.0.0 requires `simplecov ~> 1.0`, while `bashcov` 3.3.0 requires `simplecov ~> 0.21`. Bundler refuses that combination outright; the old `gem install` happily installed both simplecov 1.x and 0.22 side by side and left activation to chance. The lockfile pins a genuinely compatible set (`bashcov` 3.3.0, `simplecov-cobertura` 3.2.0, `simplecov` 0.22.0).

Verified locally in a `ruby:3.4` container: `bundle exec bashcov -- bats tests/` passes all 1219 tests and generates the Cobertura report. zizmor 1.29.0 now reports no findings on the workflows.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Unblocks #290, which fails CI purely because of this pre-existing zizmor finding. It will need a rebase once this lands.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Testing**
  * Added documented commands for reproducing coverage checks locally.
  * Standardized coverage tooling and dependency usage in CI.

* **Chores**
  * Added pinned dependencies for coverage and CI security linting.
  * Enabled improved dependency caching and automated minor/patch updates.
  * Added ignore rules for local Ruby dependency directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->